### PR TITLE
Adding podspec. 

### DIFF
--- a/CocoaSPDY.podspec
+++ b/CocoaSPDY.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => git_url, :tag => "v#{version}"}
   
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
 
   s.source_files = source_files
   s.requires_arc = true


### PR DESCRIPTION
Already pushed a podspec to the Cocoapods/Specs repo. I thought if you guys would to have one local as well.

I also rewrote the tests to use XCTest instead and use a 'local' cocoapod-based workspace with a guard.rb file. 
But that's too much of a change and my assumption is that it's not for you, but let me know if I'm wrong. 
