### PR TITLE
Expose TLS settings as a configuration option

### DIFF
--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -136,4 +136,12 @@ extern NSString *const SPDYOriginUnregisteredNotification;
 */
 @property BOOL enableSettingsMinorVersion;
 
+/**
+  TLS settings for the underlying CFSocketStream. Possible keys and 
+  values for TLS settings can be found in CFSocketStream.h
+
+  Default is no settings.
+*/
+@property NSDictionary *tlsSettings;
+
 @end

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -225,6 +225,7 @@ static SPDYConfiguration *defaultConfiguration;
     defaultConfiguration.sessionReceiveWindow = 10485760;
     defaultConfiguration.streamReceiveWindow = 10485760;
     defaultConfiguration.enableSettingsMinorVersion = YES;
+    defaultConfiguration.tlsSettings = @{ /* use Apple default TLS settings */ };
 }
 
 + (SPDYConfiguration *)defaultConfiguration
@@ -239,6 +240,7 @@ static SPDYConfiguration *defaultConfiguration;
     copy.sessionReceiveWindow = _sessionReceiveWindow;
     copy.streamReceiveWindow = _streamReceiveWindow;
     copy.enableSettingsMinorVersion = _enableSettingsMinorVersion;
+    copy.tlsSettings = _tlsSettings;
     return copy;
 }
 

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -100,7 +100,7 @@
 
             if ([_origin.scheme isEqualToString:@"https"]) {
                 SPDY_DEBUG(@"session using TLS");
-                [_socket secureWithTLS:@{ /* use Apple default TLS settings */ }];
+                [_socket secureWithTLS:configuration.tlsSettings];
             }
 
             _frameDecoder = [[SPDYFrameDecoder alloc] initWithDelegate:self];


### PR DESCRIPTION
It looks like SPDYSocket was made to take TLS options with secureWithTLS but there isn't a way to set the outside of SPDYSession. This adds TLS settings to the configuration so they can be passed on to SPDYSocket.
