### PR TITLE
fix data pollution issue

### DIFF
--- a/SPDY/SPDYFrameDecoder.m
+++ b/SPDY/SPDYFrameDecoder.m
@@ -353,9 +353,7 @@ SPDYCommonHeader getCommonHeader(uint8_t *buffer) {
 
     SPDYDataFrame *frame = [[SPDYDataFrame alloc] init];
     frame.streamId = streamId;
-    frame.data = [[NSData alloc] initWithBytesNoCopy:buffer
-                                              length:bytesToRead
-                                        freeWhenDone:NO];
+    frame.data = [[NSData alloc] initWithBytes:buffer length:bytesToRead];
 
     bytesRead = bytesToRead;
     _length -= bytesToRead;

--- a/SPDY/SPDYStream.m
+++ b/SPDY/SPDYStream.m
@@ -375,7 +375,7 @@
             [_client URLProtocol:_protocol didFailWithError:error];
         }
     } else {
-        [_client URLProtocol:_protocol didLoadData:[data copy]];
+        [_client URLProtocol:_protocol didLoadData:data];
     }
 }
 


### PR DESCRIPTION
The data buffer should be copied in advance in case <code>_currentReadOp->_buffer</code> being polluted(This bug can be reproduced easily using a single NSURLConnection App).

I thought https://github.com/twitter/CocoaSPDY/issues/23 was related with this issue.
