### PR TITLE
protect again arbitrarily large window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For NSURLSession, you can configure sessions to use SPDY via NSURLSessionConfigu
 
     #import <SPDY/SPDYProtocol.h>
     ...
+    NSURLSessionConfiguration configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.protocolClasses = @[[SPDYURLSessionProtocol class]];
 
 You can freely use either or both methods, and existing SPDY sessions will be shared across both networking stacks. If you do use the former approach, note that registered origins will also be handled by SPDY with the default NSURLSession.

--- a/SPDY/SPDYStream.m
+++ b/SPDY/SPDYStream.m
@@ -200,6 +200,8 @@
 {
     if (_dataStream) {
         if (length > 0 && _dataStream.hasBytesAvailable) {
+		
+            length = MIN(length, 1024*1024); // protect again arbitrarily large window size
             NSMutableData *writeData = [[NSMutableData alloc] initWithLength:length];
             NSInteger bytesRead = [_dataStream read:(uint8_t *)writeData.bytes maxLength:length];
 


### PR DESCRIPTION
Observed with nginx with SPDY 3.1 patch applied:

http://mailman.nginx.org/pipermail/nginx-devel/2014-January/004890.html

2014-01-28 19:08:18.230 eBay[55680:720b] SPDY [DEBUG] received
WINDOW_UPDATE.0 (+2147418111)

This causes a very large NSData allocation, and an immediate crash.
