### PR TITLE
Fix leak of SecTrustRef in SPDYSocket

### DIFF
--- a/SPDY/SPDYSocket.m
+++ b/SPDY/SPDYSocket.m
@@ -1724,6 +1724,7 @@ static void SPDYSocketCFWriteStreamCallback(CFWriteStreamRef stream, CFStreamEve
         if ([_delegate respondsToSelector:@selector(socket:securedWithTrust:)]) {
             SecTrustRef trust = (SecTrustRef)CFReadStreamCopyProperty(_readStream, kCFStreamPropertySSLPeerTrust);
             acceptTrust = [_delegate socket:self securedWithTrust:trust];
+            CFRelease(trust);
         }
 
         if (!acceptTrust) {


### PR DESCRIPTION
Fix a memory leak in SPDYSocket's _onTLSHandshakeSuccess method.
