### PR TITLE
fix compiler warnings

### DIFF
--- a/SPDY/SPDYFrameDecoder.m
+++ b/SPDY/SPDYFrameDecoder.m
@@ -334,7 +334,7 @@ SPDYCommonHeader getCommonHeader(uint8_t *buffer) {
 
 - (NSUInteger)_readDataFrame:(uint8_t *)buffer length:(NSUInteger)len
 {
-    NSUInteger streamId = _header.data.streamId;
+    SPDYStreamId streamId = _header.data.streamId;
     if (streamId == 0) {
         _state = FRAME_ERROR;
         return 0;

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -833,7 +833,7 @@
 {
     SPDYWindowUpdateFrame *windowUpdateFrame = [[SPDYWindowUpdateFrame alloc] init];
     windowUpdateFrame.streamId = streamId;
-    windowUpdateFrame.deltaWindowSize = deltaWindowSize;
+    windowUpdateFrame.deltaWindowSize = (uint32_t) deltaWindowSize;
     [_frameEncoder encodeWindowUpdateFrame:windowUpdateFrame];
     SPDY_DEBUG(@"sent WINDOW_UPDATE.%u (+%lu)", streamId, (unsigned long)deltaWindowSize);
 }


### PR DESCRIPTION
This PR fixes 2 compiler warnings about implicit conversions from NSUInteger to uint32_t.
