### PR TITLE
Check number of name/value pairs strictly

### DIFF
--- a/SPDY/SPDYFrameDecoder.m
+++ b/SPDY/SPDYFrameDecoder.m
@@ -465,6 +465,11 @@ SPDYCommonHeader getCommonHeader(uint8_t *buffer) {
                 headerCount--;
             }
 
+            if (headerCount > 0 || bufferIndex < _decompressedLength) {
+                _state = FRAME_ERROR;
+                return bytesRead;
+            }
+
             _headerBlockFrame.headers = headers;
 
             switch (_type) {


### PR DESCRIPTION
Any frame error (e.g. broken header block) should be reported. 
