### PR TITLE
Enable better control over Logging

### DIFF
--- a/SPDY/SPDYCommonLogger.m
+++ b/SPDY/SPDYCommonLogger.m
@@ -16,7 +16,9 @@
 #import "SPDYCommonLogger.h"
 
 #ifdef DEBUG
+#ifndef SPDY_DEBUG_LOGGING
 #define SPDY_DEBUG_LOGGING 1
+#endif
 #endif
 
 static const NSString *logLevels[4] = { @"ERROR", @"WARNING", @"INFO", @"DEBUG" };
@@ -48,15 +50,17 @@ static id<SPDYLogger> sharedLogger;
     NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
     va_end(args);
 
+    if (sharedLogger) {
+        dispatch_async(loggerQueue, ^{
+            if (sharedLogger) {
+                [sharedLogger log:message atLevel:level];
+            }
+        });
+    } else {
 #if SPDY_DEBUG_LOGGING
-    NSLog(@"SPDY [%@] %@", logLevels[level], message);
-#else
-    dispatch_async(loggerQueue, ^{
-        if (sharedLogger) {
-            [sharedLogger log:message atLevel:level];
-        }
-    });
+        NSLog(@"SPDY [%@] %@", logLevels[level], message);
 #endif
+    }
 }
 
 @end


### PR DESCRIPTION
I was frustrated with the inability to control my SPDY logging when `DEBUG=1`. This pull request makes 2 minor changes to improve the flexibility:
1. Respects any existing value for `SPDY_DEBUG_LOGGING` exported to the build environment
2. If a `sharedLogger` instance has been configured, it favors that logging interface over the fallback `NSLog` regardless of the value for `SPDY_DEBUG_LOGGING`
