### PR TITLE
Implement SPDY Push

### DIFF
--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -14,7 +14,7 @@
 extern NSString *const SPDYOriginRegisteredNotification;
 extern NSString *const SPDYOriginUnregisteredNotification;
 
-@class SPDYConfiguration;
+@class SPDYConfiguration, SPDYSessionManager;
 
 @protocol SPDYLogger;
 @protocol SPDYTLSTrustEvaluator;
@@ -23,6 +23,8 @@ extern NSString *const SPDYOriginUnregisteredNotification;
   Client implementation of the SPDY/3.1 draft protocol.
 */
 @interface SPDYProtocol : NSURLProtocol
+
++ (SPDYSessionManager *)sessionManager;
 
 /**
   Set configuration options to be used for all future SPDY sessions.

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -51,9 +51,19 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
 #endif
 }
 
++ (SPDYSessionManager *)sessionManager
+{
+    static SPDYSessionManager *sessionManager;
+    static dispatch_once_t predicate;
+    dispatch_once(&predicate, ^{
+        sessionManager = [SPDYSessionManager new];
+    });
+    return sessionManager;
+}
+
 + (void)setConfiguration:(SPDYConfiguration *)configuration
 {
-    [SPDYSessionManager setConfiguration:configuration];
+    [self sessionManager].configuration = configuration;
 }
 
 + (void)setLogger:(id<SPDYLogger>)logger
@@ -101,7 +111,7 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
     SPDY_INFO(@"start loading %@", request.URL.absoluteString);
 
     NSError *error;
-    _session = [SPDYSessionManager sessionForURL:request.URL error:&error];
+    _session = [[[self class] sessionManager] sessionForURL:request.URL error:&error];
     if (!_session) {
         [self.client URLProtocol:self didFailWithError:error];
     } else {

--- a/SPDY/SPDYSession.h
+++ b/SPDY/SPDYSession.h
@@ -10,16 +10,19 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SPDYStream.h"
 
 @class SPDYProtocol;
 @class SPDYConfiguration;
 @class SPDYOrigin;
+@protocol SPDYSessionDelegate;
 
-@interface SPDYSession : NSObject
+@interface SPDYSession : NSObject <SPDYStreamPushClient>
 
 @property (nonatomic, readonly) SPDYOrigin *origin;
 @property (nonatomic, readonly) bool isCellular;
 @property (nonatomic, readonly) bool isOpen;
+@property (nonatomic, weak) id<SPDYSessionDelegate> delegate;
 
 - (id)initWithOrigin:(SPDYOrigin *)origin
        configuration:(SPDYConfiguration *)configuration
@@ -28,5 +31,11 @@
 - (void)issueRequest:(SPDYProtocol *)protocol;
 - (void)cancelRequest:(SPDYProtocol *)protocol;
 - (void)close;
+
+@end
+
+@protocol SPDYSessionDelegate <NSObject>
+
+- (void)session:(SPDYSession *)session didReceivePushResponse:(NSURLResponse *)response data:(NSData *)data;
 
 @end

--- a/SPDY/SPDYSessionManager.h
+++ b/SPDY/SPDYSessionManager.h
@@ -13,11 +13,22 @@
 
 @class SPDYConfiguration;
 @class SPDYSession;
+@protocol SPDYSessionManagerDelegate;
 
 @interface SPDYSessionManager : NSObject
 
-+ (SPDYSession *)sessionForURL:(NSURL *)url error:(NSError **)pError;
-+ (void)removeSession:(SPDYSession *)session;
-+ (void)setConfiguration:(SPDYConfiguration *)configuration;
+@property (nonatomic, weak) id<SPDYSessionManagerDelegate> delegate;
+@property (nonatomic, strong) SPDYConfiguration *configuration;
+
+- (SPDYSession *)sessionForURL:(NSURL *)url error:(NSError **)pError;
+- (void)removeSession:(SPDYSession *)session;
+- (NSArray *)allSessions;
+
+@end
+
+@protocol SPDYSessionManagerDelegate <NSObject>
+
+- (void)sessionManager:(SPDYSessionManager *)sessionManager willStartSession:(SPDYSession *)session forURL:(NSURL *)URL;
+- (void)sessionManager:(SPDYSessionManager *)sessionManager willRemoveSession:(SPDYSession *)session;
 
 @end

--- a/SPDY/SPDYStream.h
+++ b/SPDY/SPDYStream.h
@@ -20,11 +20,17 @@
 - (void)streamFinished:(SPDYStream *)stream;
 @end
 
+@protocol SPDYStreamPushClient <NSObject>
+- (void)stream:(SPDYStream *)stream didReceivePushResponse:(NSURLResponse *)response data:(NSData *)data;
+@end
+
 @interface SPDYStream : NSObject
 @property (nonatomic, weak) id<NSURLProtocolClient> client;
 @property (nonatomic, weak) id<SPDYStreamDataDelegate> dataDelegate;
+@property (nonatomic, weak) id<SPDYStreamPushClient> pushClient;
 @property (nonatomic) NSData *data;
 @property (nonatomic) NSInputStream *dataStream;
+@property (nonatomic) NSDictionary *headers;
 @property (nonatomic, weak) NSURLRequest *request;
 @property (nonatomic, weak) SPDYProtocol *protocol;
 @property (nonatomic) SPDYStreamId streamId;
@@ -46,6 +52,6 @@
 - (NSData *)readData:(NSUInteger)length error:(NSError **)pError;
 - (void)closeWithError:(NSError *)error;
 - (void)closeWithStatus:(SPDYStreamStatus)status;
-- (void)didReceiveResponse:(NSDictionary *)headers;
+- (BOOL)didReceiveResponse:(NSDictionary *)headers;
 - (void)didLoadData:(NSData *)data;
 @end


### PR DESCRIPTION
This changeset introduces support for SPDY Push by utilizing a new delegate on `SPDYSession`. Closes #1

This is a focused subset of the larger changes that we have been maintaining in the @layerhq branch. This isolates the changes necessary to support SPDY Push.

Utilizing push requires registering a delegate for the `SPDYSessionManager` so that you can attach a delegate to each `SPDYSession` as it is dispatched by CocoaSPDY. You must also issue a hanging GET request so that the server has a SPDY stream that it can push responses back against. We’re using it successfully with an Erlang server utilizing the Cowboy server.
