### PR TITLE
Allow SPDY_INSTALL_SDK to be overridden

### DIFF
--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 			name = SPDYUnitTests;
 			productName = SPDYUnitTests;
 			productReference = 064EFB1316715C9F002F0AEC /* SPDYUnitTests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productType = "com.apple.product-type.bundle";
 		};
 		0651EBE716F3F7C700CE44D2 /* SPDY.iphoneos */ = {
 			isa = PBXNativeTarget;


### PR DESCRIPTION
This change allows an external project to pass in a custom install script and configuration so that the framework can be build as a subproject for debugging purposes
