### PR TITLE
Add basic metadata to response headers temporarily.

### DIFF
--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -594,7 +594,17 @@
         return;
     }
 
-    [stream didReceiveResponse:synReplyFrame.headers];
+    // Add some of the metadata as headers, to ease the transition to the new delegate way.
+    // This should be removed in the future.
+    NSMutableDictionary *headers = [synReplyFrame.headers mutableCopy];
+    headers[SPDYMetadataVersionKey] = @"3.1";
+    headers[SPDYMetadataStreamIdKey] = [[NSString alloc] initWithFormat:@"%u", streamId];
+    if (_sessionLatency > -1) {
+        NSString *sessionLatencyMs = [@((int)(_sessionLatency * 1000)) stringValue];
+        headers[SPDYMetadataSessionLatencyKey] = sessionLatencyMs;
+    }
+
+    [stream didReceiveResponse:headers];
 
     if (!stream.closed) {
         stream.remoteSideClosed = synReplyFrame.last;


### PR DESCRIPTION
To ease the transition to using the new delegate for metadata, we'll
continue reporting version, stream id, and latency in the response
headers. This maintains parity with the old behavior. This change
should be removed once all the issues have been worked through for
the delegate and its interface locks down.
