### PR TITLE
GOAWAY session unit tests and bugfix.

### DIFF
--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -731,6 +731,8 @@
             [unhandledStreams addObject:stream];
             stream.delegate = nil;
 
+            // Note: be careful of how reset mutates a stream. We need to be able to remove
+            // the stream from _activeStreams down below.
             if ([stream reset]) {
                 [_delegate session:self refusedStream:stream];
             } else {
@@ -740,7 +742,8 @@
     }
 
     for (SPDYStream *stream in unhandledStreams) {
-        [_activeStreams removeStreamWithStreamId:stream.streamId];
+        NSAssert(stream.protocol, @"expect protocol to be non-nil");
+        [_activeStreams removeStreamForProtocol:stream.protocol];
     }
 
     [_delegate sessionClosed:self];


### PR DESCRIPTION
The stream id gets reset to 0, so can't use that as the key for removing
a stream. We'll use protocol instead, since these are all local requests
and that isn't mutated by reset.
