### PR TITLE
Handle some stream delegate edge cases better.

### DIFF
--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -827,12 +827,14 @@
 
     [self _sendRstStream:SPDY_STREAM_CANCEL streamId:stream.streamId];
     stream.client = nil;
+    stream.delegate = nil;
     [_activeStreams removeStreamForProtocol:stream.protocol];
     [_delegate session:self capacityIncreased:1];
 }
 
 - (void)streamClosed:(SPDYStream *)stream
 {
+    stream.delegate = nil;
     [_activeStreams removeStreamWithStreamId:stream.streamId];
     [_delegate session:self capacityIncreased:1];
 }

--- a/SPDYUnitTests/SPDYSessionManagerTest.m
+++ b/SPDYUnitTests/SPDYSessionManagerTest.m
@@ -10,13 +10,301 @@
 //
 
 #import <SenTestingKit/SenTestingKit.h>
+#import <Foundation/Foundation.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+#import "NSURLRequest+SPDYURLRequest.h"
 #import "SPDYSession.h"
 #import "SPDYSessionManager.h"
+#import "SPDYSocket+SPDYSocketMock.h"
+#import "SPDYStream.h"
+#import "SPDYProtocol.h"
+#import "SPDYOrigin.h"
+#import "SPDYStreamManager.h"
+#import "SPDYMockFrameDecoderDelegate.h"
+
+void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info);
+
+@interface SPDYSessionPool : NSObject
+@property (nonatomic, assign, readonly) NSUInteger count;
+@property (nonatomic, assign) NSUInteger pendingCount;
+- (id)initWithOrigin:(SPDYOrigin *)origin manager:(SPDYSessionManager *)manager error:(NSError **)pError;
+- (NSUInteger)remove:(SPDYSession *)session;
+- (SPDYSession *)nextSession;
+@end
+
+@interface SPDYSessionManager (Test)
+@property (nonatomic, readonly) SPDYStreamManager *pendingStreams;
+@property (nonatomic, readonly) SPDYSessionPool *basePool;
+@property (nonatomic, readonly) SPDYSessionPool *wwanPool;
+@end
+
+@implementation SPDYSessionManager (Test)
+
+- (SPDYStreamManager *)pendingStreams
+{
+    return [self valueForKey:@"_pendingStreams"];
+}
+
+- (SPDYSessionPool *)basePool
+{
+    return [self valueForKey:@"_basePool"];
+}
+
+- (SPDYSessionPool *)wwanPool
+{
+    return [self valueForKey:@"_wwanPool"];
+}
+
+@end
+
 
 @interface SPDYSessionManagerTest : SenTestCase
 
 @end
 
 @implementation SPDYSessionManagerTest
+{
+    SPDYMockFrameDecoderDelegate *_mockDecoderDelegate;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    [SPDYSocket performSwizzling:YES];
+    _mockDecoderDelegate = [[SPDYMockFrameDecoderDelegate alloc] init];
+    socketMock_frameDecoder = [[SPDYFrameDecoder alloc] initWithDelegate:_mockDecoderDelegate];
+
+    SPDYConfiguration *configuration = [SPDYConfiguration defaultConfiguration];
+    configuration.sessionPoolSize = 1;
+    configuration.enableTCPNoDelay = NO;
+    [SPDYProtocol setConfiguration:configuration];
+}
+
+- (void)tearDown
+{
+    socketMock_frameDecoder = nil;
+    [SPDYSocket performSwizzling:NO];
+    [super tearDown];
+}
+
+- (NSString *)nextOriginUrl
+{
+    static int sCount = 0;
+    return [NSString stringWithFormat:@"https://mocked%d.com", sCount++];
+}
+
+- (void)testDispatchQueuedStreamThenDoubleCanceledDoesReleaseStreamAndNotAssert
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYStream * __weak weakStream = nil;
+    @autoreleasepool {
+        SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+        weakStream = stream;
+        urlRequest.SPDYDeferrableInterval = 0;
+        stream.request = urlRequest;
+
+        // Assert initial state
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+        STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+        // Force base pool (non-cellular) reachability and then queue the stream
+        SPDYReachabilityCallback(NULL, kSCNetworkReachabilityFlagsReachable, (__bridge void *)sessionManager);
+        [sessionManager queueStream:stream];
+
+        // Assert stream is queued
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+        STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+        // Force callback to SPDYSessionManager's session:connectedToNetwork
+        SPDYSession *session = [[sessionManager basePool] nextSession];
+        [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+
+        // Assert stream has been dispatched
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+        STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+        // Assert a SYN_STREAM was written to the socket
+        STAssertTrue([_mockDecoderDelegate.lastFrame isKindOfClass:[SPDYSynStreamFrame class]], nil);
+
+        // Ensure a double cancel doesn't trigger an NSAssert
+        [stream cancel];
+        [stream cancel];
+
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+
+        [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    }
+
+    STAssertNil(weakStream, nil);
+}
+
+- (void)testDispatchQueuedStreamThenSessionClosesDoesReleaseStreamAndRemoveSession
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYStream * __weak weakStream = nil;
+    @autoreleasepool {
+        SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+        weakStream = stream;
+        urlRequest.SPDYDeferrableInterval = 0;
+        stream.request = urlRequest;
+
+        // Force base pool (non-cellular) reachability and then queue the stream
+        SPDYReachabilityCallback(NULL, kSCNetworkReachabilityFlagsReachable, (__bridge void *)sessionManager);
+        [sessionManager queueStream:stream];
+
+        // Force callback to SPDYSessionManager's session:connectedToNetwork
+        SPDYSession *session = [[sessionManager basePool] nextSession];
+        [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+
+        // Force socket to close session and remove streams
+        [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+
+        // Force socket to disconnect and remove session
+        [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+    }
+
+    STAssertNil(weakStream, nil);
+}
+
+- (void)testReachabilityChangesAfterQueueingStreamDoesDispatchNewStreamToNewSession
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    urlRequest.SPDYDeferrableInterval = 0;
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYProtocol *protocol2 = [[SPDYProtocol alloc] init];
+    SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+    stream.request = urlRequest;
+    SPDYStream *stream2 = [[SPDYStream alloc] initWithProtocol:protocol2];
+    stream2.request = urlRequest;
+
+    // Force reachability and queue stream1
+    SPDYReachabilityCallback(NULL, kSCNetworkReachabilityFlagsReachable, (__bridge void *)sessionManager);
+    [sessionManager queueStream:stream];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+    // Change reachability and queue stream2
+    SPDYReachabilityCallback(NULL, kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN, (__bridge void *)sessionManager);
+    [sessionManager queueStream:stream2];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)2, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+
+    // Force callback to SPDYSessionManager's wwan session:connectedToNetwork and dispatch stream
+    SPDYSession *session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+    session = [[sessionManager basePool] nextSession];
+    STAssertEquals(session.activeStreams.count, (NSUInteger)0, nil);
+    session = [[sessionManager wwanPool] nextSession];
+    STAssertEquals(session.activeStreams.count, (NSUInteger)2, nil);
+
+    // Force socket to close base session and remove streams
+    session = [[sessionManager basePool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+
+    session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+}
+
+- (void)testQueueStreamToWrongPoolAndReachabilityChangesBeforeConnectionFailsDoesDispatchToNewSession
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    urlRequest.SPDYDeferrableInterval = 0;
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+    stream.request = urlRequest;
+    SPDYProtocol *protocol2 = [[SPDYProtocol alloc] init];
+    SPDYStream *stream2 = [[SPDYStream alloc] initWithProtocol:protocol2];
+    stream2.request = urlRequest;
+
+    // Force reachability and queue stream1
+    SPDYReachabilityCallback(NULL, kSCNetworkReachabilityFlagsReachable, (__bridge void *)sessionManager);
+    [sessionManager queueStream:stream];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+    // Put stream1 into wrong pool artificially
+    SPDYSession *session = [[sessionManager basePool] nextSession];
+    [session setCellular:true];
+
+    // Force session connection error
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+    STAssertFalse(session.isOpen, nil);
+
+    // We put the stream in the basePool but it thinks it is wwan. That case *should* be handled
+    // by the session manager.
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+    // Change reachability. This will dispatch. We'll also force a dispatch.
+    SPDYReachabilityCallback(NULL, kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN, (__bridge void *)sessionManager);
+    [sessionManager queueStream:stream2];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)2, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+
+    session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+    STAssertTrue(session.isOpen, nil);
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+    session = [[sessionManager wwanPool] nextSession];
+    STAssertEquals(session.activeStreams.count, (NSUInteger)2, nil);
+
+    // Force socket to close wwan session and remove streams
+    session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+}
 
 @end

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.h
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.h
@@ -13,6 +13,7 @@
 #import "SPDYSession.h"
 
 @class SPDYFrameDecoder;
+@class SPDYStreamManager;
 
 // Note: these are exposed as globals only because we don't control the creation of the
 // SPDYSocket inside CocoaSPDY, and we cannot add ivars in a category. This is the best
@@ -51,4 +52,6 @@ extern SPDYFrameDecoder *socketMock_frameDecoder;
 @property (nonatomic, readonly) SPDYSocket *socket;
 @property (nonatomic, readonly) NSMutableData *inputBuffer;
 @property (nonatomic, readonly) SPDYFrameDecoder *frameDecoder;
+@property (nonatomic, readonly) SPDYStreamManager *activeStreams;
+- (void)setCellular:(bool)cellular;
 @end

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
@@ -11,6 +11,7 @@
 
 #import "SPDYSocket+SPDYSocketMock.h"
 #import "SPDYFrameDecoder.h"
+#import "SPDYStreamManager.h"
 #import <objc/runtime.h>
 
 NSString * const kSPDYTSTResponseStubs = @"kSPDYTSTResponseStubs";
@@ -33,6 +34,16 @@ SPDYFrameDecoder *socketMock_frameDecoder = nil;
 - (SPDYFrameDecoder *)frameDecoder
 {
     return [self valueForKey:@"_frameDecoder"];
+}
+
+- (SPDYStreamManager *)activeStreams
+{
+    return [self valueForKey:@"_activeStreams"];
+}
+
+- (void)setCellular:(bool)cellular
+{
+    [self setValue:@(cellular) forKey:@"_cellular"];
 }
 
 @end


### PR DESCRIPTION
The NSAssert in SPDYSessionManager in streamCanceled has been seen to
fire, so this change attempts to address those by very explicitly
managing the stream's delegate pointer when ownership of the stream
changes.

Also includes some unit tests covering these cases. They ended up
requiring a lot of set up code and internal knowledge, but it's
good enough for now.
