### PR TITLE
Handle some stream delegate edge cases better.

### DIFF
--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -827,12 +827,14 @@
 
     [self _sendRstStream:SPDY_STREAM_CANCEL streamId:stream.streamId];
     stream.client = nil;
+    stream.delegate = nil;
     [_activeStreams removeStreamForProtocol:stream.protocol];
     [_delegate session:self capacityIncreased:1];
 }
 
 - (void)streamClosed:(SPDYStream *)stream
 {
+    stream.delegate = nil;
     [_activeStreams removeStreamWithStreamId:stream.streamId];
     [_delegate session:self capacityIncreased:1];
 }

--- a/SPDY/SPDYSessionManager.m
+++ b/SPDY/SPDYSessionManager.m
@@ -259,6 +259,7 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
     NSAssert(_pendingStreams[stream.protocol], @"stream delegate must be managing stream");
 
     [_pendingStreams removeStreamForProtocol:stream.protocol];
+    stream.delegate = nil;
 }
 
 - (void)streamClosed:(SPDYStream *)stream
@@ -291,6 +292,7 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
         *activePool = [[SPDYSessionPool alloc] initWithOrigin:_origin manager:self cellular:cellular error:&pError];
         if (pError) {
             for (SPDYStream *stream in _pendingStreams) {
+                stream.delegate = nil;
                 SPDYProtocol *protocol = stream.protocol;
                 [protocol.client URLProtocol:protocol didFailWithError:pError];
             }
@@ -326,6 +328,7 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
             for (int j = 0; j < count; j++) {
                 SPDYStream *stream = [_pendingStreams nextPriorityStream];
                 [_pendingStreams removeStreamForProtocol:stream.protocol];
+                stream.delegate = nil;
                 [session openStream:stream];
             }
         }


### PR DESCRIPTION
The NSAssert in SPDYSessionManager in streamCanceled has been seen to
fire, so this change attempts to address those by very explicitly
managing the stream's delegate pointer when ownership of the stream
changes.

Tests included later.
