### PR TITLE
Improved logging with runtime levels.

### DIFF
--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		06FDA21716717F5E00137DBD /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CC14D2161B608C002E37CF /* CFNetwork.framework */; };
 		25959A3F1937DE3900FC9731 /* SPDYSessionManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25959A3E1937DE3900FC9731 /* SPDYSessionManagerTest.m */; };
 		5C2229591952257800CAF160 /* SPDYURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C2229581952257800CAF160 /* SPDYURLRequestTest.m */; };
+		5C2A211D19F9CA0E00D0EA76 /* SPDYLoggingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */; };
 		7774C1318AB029C6BCEF84D6 /* SPDYSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7774C2026A4DE9957D75F629 /* SPDYSessionTest.m */; };
 		7774C1F1E544793907908882 /* SPDYMockFrameEncoderDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7774C69089A6978113F0C275 /* SPDYMockFrameEncoderDelegate.m */; };
 		7774CA1FA1F4A59CA0906BB7 /* SPDYSocket+SPDYSocketMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 7774C0ECD0C6E5D73FB38752 /* SPDYSocket+SPDYSocketMock.m */; };
@@ -146,6 +147,7 @@
 		4FE891C7065B348CC7EF4BFC /* SPDYHeaderBlockDecompressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYHeaderBlockDecompressor.h; sourceTree = "<group>"; };
 		4FE895BE087AC28BBBC857F9 /* SPDYHeaderBlockDecompressor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYHeaderBlockDecompressor.m; sourceTree = "<group>"; };
 		5C2229581952257800CAF160 /* SPDYURLRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYURLRequestTest.m; sourceTree = "<group>"; };
+		5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYLoggingTest.m; sourceTree = "<group>"; };
 		7774C0ECD0C6E5D73FB38752 /* SPDYSocket+SPDYSocketMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SPDYSocket+SPDYSocketMock.m"; sourceTree = "<group>"; };
 		7774C2026A4DE9957D75F629 /* SPDYSessionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYSessionTest.m; sourceTree = "<group>"; };
 		7774C69089A6978113F0C275 /* SPDYMockFrameEncoderDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYMockFrameEncoderDelegate.m; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 			children = (
 				064EFB1A16715C9F002F0AEC /* Supporting Files */,
 				069AA03816975B65005A72CA /* SPDYFrameCodecTest.m */,
+				5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */,
 				0679F3CE186217FC006F122E /* SPDYOriginTest.m */,
 				25959A3E1937DE3900FC9731 /* SPDYSessionManagerTest.m */,
 				7774C2026A4DE9957D75F629 /* SPDYSessionTest.m */,
@@ -404,7 +407,7 @@
 			name = SPDYUnitTests;
 			productName = SPDYUnitTests;
 			productReference = 064EFB1316715C9F002F0AEC /* SPDYUnitTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 		0651EBE716F3F7C700CE44D2 /* SPDY.iphoneos */ = {
 			isa = PBXNativeTarget;
@@ -556,6 +559,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				06FDA20616717DF100137DBD /* SPDYSocket.m in Sources */,
+				5C2A211D19F9CA0E00D0EA76 /* SPDYLoggingTest.m in Sources */,
 				06FDA20916717DF100137DBD /* SPDYFrame.m in Sources */,
 				06FDA20B16717DF100137DBD /* SPDYFrameDecoder.m in Sources */,
 				0679F3CF186217FC006F122E /* SPDYOriginTest.m in Sources */,

--- a/SPDY/SPDYCommonLogger.h
+++ b/SPDY/SPDYCommonLogger.h
@@ -12,38 +12,39 @@
 #import <Foundation/Foundation.h>
 #import "SPDYLogger.h"
 
-#ifdef DEBUG
-#define SPDY_LOG_LEVEL 4
-#else
-#define SPDY_LOG_LEVEL 0
-#endif
+extern volatile SPDYLogLevel __sharedLoggerLevel;
 
-#define SPDY_DEBUG(message, ...)
-#define SPDY_INFO(message, ...)
-#define SPDY_WARNING(message, ...)
-#define SPDY_ERROR(message, ...)
+// Only needed in tests and maybe debugging
+extern dispatch_queue_t __sharedLoggerQueue;
 
-#if SPDY_LOG_LEVEL >= 3
-#undef SPDY_DEBUG
-#define SPDY_DEBUG(message, ...) [SPDYCommonLogger log:message atLevel:SPDYLogLevelDebug, ##__VA_ARGS__]
-#endif
+#define LOG_LEVEL_ENABLED(l) ((l) <= __sharedLoggerLevel)
 
-#if SPDY_LOG_LEVEL >= 2
-#undef SPDY_INFO
-#define SPDY_INFO(message, ...) [SPDYCommonLogger log:message atLevel:SPDYLogLevelInfo, ##__VA_ARGS__]
-#endif
+#define SPDY_DEBUG(message, ...) do { \
+    if (LOG_LEVEL_ENABLED(SPDYLogLevelDebug)) { \
+       [SPDYCommonLogger log:message atLevel:SPDYLogLevelDebug, ##__VA_ARGS__]; \
+    } \
+} while (0)
 
-#if SPDY_LOG_LEVEL >= 1
-#undef SPDY_WARNING
-#define SPDY_WARNING(message, ...) [SPDYCommonLogger log:message atLevel:SPDYLogLevelWarning, ##__VA_ARGS__]
-#endif
+#define SPDY_INFO(message, ...) do { \
+    if (LOG_LEVEL_ENABLED(SPDYLogLevelInfo)) { \
+       [SPDYCommonLogger log:message atLevel:SPDYLogLevelInfo, ##__VA_ARGS__]; \
+    } \
+} while (0)
 
-#if SPDY_LOG_LEVEL >= 0
-#undef SPDY_ERROR
-#define SPDY_ERROR(message, ...) [SPDYCommonLogger log:message atLevel:SPDYLogLevelError, ##__VA_ARGS__]
-#endif
+#define SPDY_WARNING(message, ...) do { \
+    if (LOG_LEVEL_ENABLED(SPDYLogLevelWarning)) { \
+       [SPDYCommonLogger log:message atLevel:SPDYLogLevelWarning, ##__VA_ARGS__]; \
+    } \
+} while (0)
+
+#define SPDY_ERROR(message, ...) do { \
+    if (LOG_LEVEL_ENABLED(SPDYLogLevelError)) { \
+       [SPDYCommonLogger log:message atLevel:SPDYLogLevelError, ##__VA_ARGS__]; \
+    } \
+} while (0)
 
 @interface SPDYCommonLogger : NSObject
 + (void)setLogger:(id<SPDYLogger>)logger;
++ (void)setLoggerLevel:(SPDYLogLevel)level;
 + (void)log:(NSString *)format atLevel:(SPDYLogLevel)level, ... NS_FORMAT_FUNCTION(1,3);
 @end

--- a/SPDY/SPDYCommonLogger.m
+++ b/SPDY/SPDYCommonLogger.m
@@ -15,30 +15,38 @@
 
 #import "SPDYCommonLogger.h"
 
-#ifdef DEBUG
-#define SPDY_DEBUG_LOGGING 1
-#endif
-
 static const NSString *logLevels[4] = { @"ERROR", @"WARNING", @"INFO", @"DEBUG" };
 
 @implementation SPDYCommonLogger
 
-static dispatch_once_t initialized;
-static dispatch_queue_t loggerQueue;
-static id<SPDYLogger> sharedLogger;
+static dispatch_once_t __initialized;
+dispatch_queue_t __sharedLoggerQueue;
+static id<SPDYLogger> __sharedLogger;
+volatile SPDYLogLevel __sharedLoggerLevel;
 
 + (void)initialize
 {
-    dispatch_once(&initialized, ^{
-        loggerQueue = dispatch_queue_create("com.twitter.SPDYProtocolLoggerQueue", DISPATCH_QUEUE_SERIAL);
+    dispatch_once(&__initialized, ^{
+        __sharedLoggerQueue = dispatch_queue_create("com.twitter.SPDYProtocolLoggerQueue", DISPATCH_QUEUE_SERIAL);
+        __sharedLogger = nil;
+#ifdef DEBUG
+        __sharedLoggerLevel = SPDYLogLevelDebug;
+#else
+        __sharedLoggerLevel = SPDYLogLevelError;
+#endif
     });
 }
 
 + (void)setLogger:(id<SPDYLogger>)logger
 {
-    dispatch_async(loggerQueue, ^{
-        sharedLogger = logger;
+    dispatch_async(__sharedLoggerQueue, ^{
+        __sharedLogger = logger;
     });
+}
+
++ (void)setLoggerLevel:(SPDYLogLevel)level
+{
+    __sharedLoggerLevel = level;
 }
 
 + (void)log:(NSString *)format atLevel:(SPDYLogLevel)level, ... NS_FORMAT_FUNCTION(1,3)
@@ -48,15 +56,16 @@ static id<SPDYLogger> sharedLogger;
     NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
     va_end(args);
 
-#if SPDY_DEBUG_LOGGING
-    NSLog(@"SPDY [%@] %@", logLevels[level], message);
-#else
-    dispatch_async(loggerQueue, ^{
-        if (sharedLogger) {
-            [sharedLogger log:message atLevel:level];
+    dispatch_async(__sharedLoggerQueue, ^{
+        if (__sharedLogger) {
+            [__sharedLogger log:message atLevel:level];
         }
-    });
+#ifdef DEBUG
+        else {
+            NSLog(@"SPDY [%@] %@", logLevels[level], message);
+        }
 #endif
+    });
 }
 
 @end

--- a/SPDY/SPDYLogger.h
+++ b/SPDY/SPDYLogger.h
@@ -10,6 +10,7 @@
 //
 
 typedef enum {
+    SPDYLogLevelDisabled = -1,
     SPDYLogLevelError = 0,
     SPDYLogLevelWarning,
     SPDYLogLevelInfo,

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -10,6 +10,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SPDYLogger.h"
 
 extern NSString *const SPDYOriginRegisteredNotification;
 extern NSString *const SPDYOriginUnregisteredNotification;
@@ -37,7 +38,6 @@ extern NSString *const SPDYMetadataSessionLatencyKey;
 
 @class SPDYConfiguration;
 
-@protocol SPDYLogger;
 @protocol SPDYTLSTrustEvaluator;
 
 /**
@@ -62,6 +62,11 @@ extern NSString *const SPDYMetadataSessionLatencyKey;
   Note that log messages are dispatched asynchronously.
  */
 + (void)setLogger:(id<SPDYLogger>)logger;
+
+/**
+  Set minimum logging level.
+*/
++ (void)setLoggerLevel:(SPDYLogLevel)level;
 
 /**
   Register an object to perform additional evaluation of TLS certificates.

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -79,6 +79,11 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
     [SPDYCommonLogger setLogger:logger];
 }
 
++ (void)setLoggerLevel:(SPDYLogLevel)level
+{
+    [SPDYCommonLogger setLoggerLevel:level];
+}
+
 + (void)setTLSTrustEvaluator:(id<SPDYTLSTrustEvaluator>)evaluator
 {
     SPDY_INFO(@"register trust evaluator: %@", evaluator);

--- a/SPDYUnitTests/SPDYLoggingTest.m
+++ b/SPDYUnitTests/SPDYLoggingTest.m
@@ -1,0 +1,175 @@
+//
+//  SPDYLoggingTest.m
+//  SPDY
+//
+//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "SPDYCommonLogger.h"
+
+@interface SPDYLoggingTest : SenTestCase <SPDYLogger>
+@end
+
+@implementation SPDYLoggingTest
+{
+    NSString *_lastMessage;
+    SPDYLogLevel _lastLevel;
+}
+
+- (void)log:(NSString *)message atLevel:(SPDYLogLevel)logLevel
+{
+    NSLog(@"Got log message: %@", message);
+    _lastMessage = message;
+    _lastLevel = logLevel;
+
+    if ([message rangeOfString:@"delay"].length != 0) {
+        sleep(1);
+    }
+}
+
+- (void)setUp
+{
+    _lastMessage = nil;
+    _lastLevel = -1;
+}
+
+- (void)tearDown
+{
+    [SPDYCommonLogger setLogger:nil];
+}
+
+- (BOOL)logAndWaitAtLevel:(SPDYLogLevel)level expectLog:(BOOL)expectLog
+{
+    _lastMessage = nil;
+    _lastLevel = -1;
+
+    switch (level) {
+        case SPDYLogLevelDebug:
+            SPDY_DEBUG(@"debug %d", 1);
+            break;
+        case SPDYLogLevelInfo:
+            SPDY_INFO(@"info %d", 1);
+            break;
+        case SPDYLogLevelWarning:
+            SPDY_WARNING(@"warning %d", 1);
+            break;
+        case SPDYLogLevelError:
+            SPDY_ERROR(@"error %d", 1);
+            break;
+        case SPDYLogLevelDisabled:
+            STAssertTrue(NO, @"not a valid log level");
+            break;
+    }
+
+
+    dispatch_sync(__sharedLoggerQueue, ^{
+        // Don't need to do anything. Just need this to run and return.
+    });
+
+    if (_lastMessage == nil && !expectLog) {
+        return YES;
+    }
+
+    switch (level) {
+        case SPDYLogLevelDebug:
+            STAssertEqualObjects(_lastMessage, @"debug 1", nil);
+            STAssertEquals(_lastLevel, SPDYLogLevelDebug, nil);
+            break;
+        case SPDYLogLevelInfo:
+            STAssertEqualObjects(_lastMessage, @"info 1", nil);
+            STAssertEquals(_lastLevel, SPDYLogLevelInfo, nil);
+            break;
+        case SPDYLogLevelWarning:
+            STAssertEqualObjects(_lastMessage, @"warning 1", nil);
+            STAssertEquals(_lastLevel, SPDYLogLevelWarning, nil);
+            break;
+        case SPDYLogLevelError:
+            STAssertEqualObjects(_lastMessage, @"error 1", nil);
+            STAssertEquals(_lastLevel, SPDYLogLevelError, nil);
+            break;
+        case SPDYLogLevelDisabled:
+            break;
+    }
+
+    return NO;
+}
+
+- (void)testLoggingAtDebugLevel
+{
+    [SPDYCommonLogger setLogger:self];
+    [SPDYCommonLogger setLoggerLevel:SPDYLogLevelDebug];
+
+    [self logAndWaitAtLevel:SPDYLogLevelDebug expectLog:YES];
+    [self logAndWaitAtLevel:SPDYLogLevelInfo expectLog:YES];
+    [self logAndWaitAtLevel:SPDYLogLevelWarning expectLog:YES];
+    [self logAndWaitAtLevel:SPDYLogLevelError expectLog:YES];
+}
+
+- (void)testLoggingAtInfoLevel
+{
+    [SPDYCommonLogger setLogger:self];
+    [SPDYCommonLogger setLoggerLevel:SPDYLogLevelInfo];
+
+    [self logAndWaitAtLevel:SPDYLogLevelDebug expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelInfo expectLog:YES];
+    [self logAndWaitAtLevel:SPDYLogLevelWarning expectLog:YES];
+    [self logAndWaitAtLevel:SPDYLogLevelError expectLog:YES];
+}
+
+- (void)testLoggingAtWarningLevel
+{
+    [SPDYCommonLogger setLogger:self];
+    [SPDYCommonLogger setLoggerLevel:SPDYLogLevelWarning];
+
+    [self logAndWaitAtLevel:SPDYLogLevelDebug expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelInfo expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelWarning expectLog:YES];
+    [self logAndWaitAtLevel:SPDYLogLevelError expectLog:YES];
+}
+
+- (void)testLoggingAtErrorLevel
+{
+    [SPDYCommonLogger setLogger:self];
+    [SPDYCommonLogger setLoggerLevel:SPDYLogLevelError];
+
+    [self logAndWaitAtLevel:SPDYLogLevelDebug expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelInfo expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelWarning expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelError expectLog:YES];
+}
+
+- (void)testLoggingWhenDisabled
+{
+    [SPDYCommonLogger setLogger:self];
+    [SPDYCommonLogger setLoggerLevel:SPDYLogLevelDisabled];
+
+    [self logAndWaitAtLevel:SPDYLogLevelDebug expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelInfo expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelWarning expectLog:NO];
+    [self logAndWaitAtLevel:SPDYLogLevelError expectLog:NO];
+}
+
+- (void)testLoggingWhenNil
+{
+    [SPDYCommonLogger setLogger:nil];
+    [SPDYCommonLogger setLoggerLevel:SPDYLogLevelError];
+
+    SPDY_DEBUG(@"debug %d", 1);
+    STAssertNil(_lastMessage,  nil);
+
+    SPDY_INFO(@"info %d", 1);
+    STAssertNil(_lastMessage,  nil);
+
+    SPDY_WARNING(@"warning %d", 1);
+    STAssertNil(_lastMessage,  nil);
+
+    SPDY_ERROR(@"error %d", 1);
+    STAssertNil(_lastMessage,  nil);
+}
+
+@end

--- a/SPDYUnitTests/SPDYSessionTest.m
+++ b/SPDYUnitTests/SPDYSessionTest.m
@@ -88,7 +88,7 @@
     [super tearDown];
 }
 
-- (SPDYProtocol *)newProtocol
+- (SPDYProtocol *)createProtocol
 {
     SPDYProtocol *protocolRequest = [[SPDYProtocol alloc] initWithRequest:_URLRequest cachedResponse:nil client:nil];
     [_protocolList addObject:protocolRequest];
@@ -127,7 +127,7 @@
 
     // 1.) Issue a HTTP request towards the server, this will send the SYN_STREAM request and wait
     // for the SYN_REPLY. It will use stream-id of 1 since it's the first request.
-    [_session openStream:[[SPDYStream alloc] initWithProtocol:[self newProtocol]]];
+    [_session openStream:[[SPDYStream alloc] initWithProtocol:[self createProtocol]]];
     STAssertTrue([_mockDecoderDelegate.lastFrame isKindOfClass:[SPDYSynStreamFrame class]], nil);
     [_mockDecoderDelegate clear];
 
@@ -223,11 +223,11 @@
     [self mockSynStreamAndReplyWithId:1 last:YES];
 
     // Send two SYN_STREAMs only, no reply
-    [_session openStream:[[SPDYStream alloc] initWithProtocol:[self newProtocol]]];
+    [_session openStream:[[SPDYStream alloc] initWithProtocol:[self createProtocol]]];
     STAssertTrue([_mockDecoderDelegate.lastFrame isKindOfClass:[SPDYSynStreamFrame class]], nil);
     [_mockDecoderDelegate clear];
 
-    [_session openStream:[[SPDYStream alloc] initWithProtocol:[self newProtocol]]];
+    [_session openStream:[[SPDYStream alloc] initWithProtocol:[self createProtocol]]];
     STAssertTrue([_mockDecoderDelegate.lastFrame isKindOfClass:[SPDYSynStreamFrame class]], nil);
     [_mockDecoderDelegate clear];
 


### PR DESCRIPTION
Logging is now enabled for all build flavors. Levels can be turned on
and off at runtime, and this functionality is exposed externally. This
also exposes the ability to optionally set the logging dispatch queue.

The default for debug builds is DEBUG level (everything), while
release builds default to ERROR level. The app can also set the
DISABLED level, which will turn off all logging.

If no logger has been attached, then NSLog will be used, but only for
debug builds and only if the logging level is met.
