### PR TITLE
Fix early release of SPDYMetadata.

### DIFF
--- a/SPDY/SPDYMetadata.m
+++ b/SPDY/SPDYMetadata.m
@@ -9,14 +9,15 @@
 //  Created by Michael Schore
 //
 
+#import <objc/runtime.h>
+#import "SPDYCommonLogger.h"
 #import "SPDYMetadata.h"
 #import "SPDYProtocol.h"
 #import "SPDYStopwatch.h"
 
+static const char *kMetadataAssociatedObjectKey = "SPDYMetadataAssociatedObject";
+
 @implementation SPDYMetadata
-{
-    NSString *_identifier;
-}
 
 /**
   Note about the SPDYMetadata identifier:
@@ -26,35 +27,11 @@
   can request the metadata multiple times if it wants to track progress, or else wait until the
   connectionDidFinishLoading callback to get the final metadata.
 
-  This is achieved by storing an opaque weak identifier in the headers/userInfo. This is used to
-  look up the metadata in a dictionary with weak objects. The deallocation of the SPDYMetadata will
-  remove the dictionary entry, though the object references will also be zeroed upon release.
-
-  Lifetime of the SPDYMetadata is guaranteed by SPDYStream holding a strong reference to the
-  SPDYMetadata, and an instance of SPDYProtocol (created by the URL loading system) holding
-  a strong reference to the SPDYStream. As long as the URL loading system is being used for
-  the NSURLProtocolClient delegate calls, the SPDYMetadata will be alive. It's after the
-  last delegate call returns and everything is shutting down that the metadata will be released.
-
-  We prevent such bad behavior by using the dictionary with weak object references, and extra
-  insurance is provided by concatenating the SPDYMetadata's init timestamp with its pointer, in
-  order to guarantee uniqueness in the case of memory address re-use and cached responses surviving
-  across process invocations.
+  This is achieved by associating an instance of SPDYMetadata with an NSString instance used
+  as the identifier. As long as that identifier is alive, the metadata will be available.
 */
 
 static NSString * const SPDYMetadataIdentifierKey = @"x-spdy-metadata-identifier";
-
-static dispatch_once_t __initIdentifiers;
-static dispatch_queue_t __identifiersQueue;
-static NSMapTable *__identifiers;
-
-+ (void)initialize
-{
-    dispatch_once(&__initIdentifiers, ^{
-        __identifiersQueue = dispatch_queue_create("com.twitter.SPDYMetadataQueue", DISPATCH_QUEUE_CONCURRENT);
-        __identifiers = [NSMapTable strongToWeakObjectsMapTable];
-    });
-}
 
 - (id)init
 {
@@ -69,29 +46,8 @@ static NSMapTable *__identifiers;
         _blockedMs = 0;
         _hostAddress = nil;
         _hostPort = 0;
-
-        NSUInteger ptr = (NSUInteger)self;
-        SPDYTimeInterval timestamp = [SPDYStopwatch currentSystemTime];
-        _identifier = [NSString stringWithFormat:@"%f/%tx", timestamp, ptr];
-
-        dispatch_barrier_async(__identifiersQueue, ^{
-            [__identifiers setObject:self forKey:_identifier];
-        });
     }
     return self;
-}
-
-- (void)dealloc
-{
-    NSString *identifier = _identifier;
-    dispatch_barrier_async(__identifiersQueue, ^{
-        [__identifiers removeObjectForKey:identifier];
-    });
-}
-
-- (NSString *)identifier
-{
-    return _identifier;
 }
 
 - (NSDictionary *)dictionary
@@ -122,22 +78,24 @@ static NSMapTable *__identifiers;
 
 + (void)setMetadata:(SPDYMetadata *)metadata forAssociatedDictionary:(NSMutableDictionary *)dictionary
 {
-    // This is a weak reference
-    dictionary[SPDYMetadataIdentifierKey] = [metadata identifier];
+    // We need to create a new instance of each identifier we assign to a dictionary. The value
+    // of the identifier doesn't actually matter, but a unique one is useful for debugging.
+    CFAbsoluteTime timestamp = CFAbsoluteTimeGetCurrent();
+    NSString *identifier = [NSString stringWithFormat:@"%f/%tx", timestamp, (NSUInteger)metadata];
+    objc_setAssociatedObject(identifier, kMetadataAssociatedObjectKey, metadata, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    dictionary[SPDYMetadataIdentifierKey] = identifier;
 }
 
 + (SPDYMetadata *)metadataForAssociatedDictionary:(NSDictionary *)dictionary;
 {
     NSString *identifier = dictionary[SPDYMetadataIdentifierKey];
-    SPDYMetadata __block *metadata = nil;
-
     if (identifier.length > 0) {
-        dispatch_sync(__identifiersQueue, ^{
-            metadata = [__identifiers objectForKey:identifier];
-        });
+        id associatedObject = objc_getAssociatedObject(identifier, kMetadataAssociatedObjectKey);
+        if ([associatedObject isKindOfClass:[SPDYMetadata class]]) {
+            return associatedObject;
+        }
     }
-
-    return metadata;
+    return nil;
 }
 
 @end

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -94,11 +94,10 @@ extern NSString *const SPDYMetadataStreamTxBytesKey;
 + (bool)evaluateServerTrust:(SecTrustRef)trust forHost:(NSString *)host;
 
 /*
-  Retrieve the SPDY metadata from either the response or the response headers returned in
-  connection:didReceiveResponse. Should be called during the connectionDidFinishLoading
-  callback only, and use at any other time is undefined.
+  Retrieve the SPDY metadata from the response returned in connection:didReceiveResponse.
+  Should be called during the connectionDidFinishLoading callback only, and use at any other
+  time is undefined.
 */
-+ (NSDictionary *)metadataForResponseHeaders:(NSDictionary *)responseHeaders;
 + (NSDictionary *)metadataForResponse:(NSURLResponse *)response;
 
 /*

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -118,16 +118,11 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
     return [evaluator evaluateServerTrust:trust forHost:host];
 }
 
-+ (NSDictionary *)metadataForResponseHeaders:(NSDictionary *)responseHeaders
-{
-    SPDYMetadata *metadata = [SPDYMetadata metadataForAssociatedDictionary:responseHeaders];
-    return (metadata != nil) ? [metadata dictionary] : @{};
-}
-
 + (NSDictionary *)metadataForResponse:(NSURLResponse *)response
 {
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-    return [self metadataForResponseHeaders:httpResponse.allHeaderFields];
+    SPDYMetadata *metadata = [SPDYMetadata metadataForAssociatedDictionary:httpResponse.allHeaderFields];
+    return (metadata != nil) ? [metadata dictionary] : @{};
 }
 
 + (NSDictionary *)metadataForError:(NSError *)error

--- a/SPDYUnitTests/SPDYMetadataTest.m
+++ b/SPDYUnitTests/SPDYMetadataTest.m
@@ -121,7 +121,7 @@
     STAssertNil(metadata, nil);
 }
 
-- (void)testAssociatedDictionaryAfterDealloc
+- (void)testMetadataAfterReleaseShouldNotBeNil
 {
     NSMutableDictionary *associatedDictionary = [[NSMutableDictionary alloc] init];
     SPDYMetadata * __weak weakOriginalMetadata = nil;
@@ -133,8 +133,22 @@
 
     SPDYMetadata *metadata = [SPDYMetadata metadataForAssociatedDictionary:associatedDictionary];
 
+    // Since the identifier maintains a reference, these will be alive
+    STAssertNotNil(weakOriginalMetadata, nil);
+    STAssertNotNil(metadata, nil);
+}
+
+- (void)testMetadataAfterAssociatedDictionaryDeallocShouldBeNil
+{
+    SPDYMetadata * __weak weakOriginalMetadata = nil;
+    @autoreleasepool {
+        SPDYMetadata *originalMetadata = [self createTestMetadata];
+        weakOriginalMetadata = originalMetadata;
+        NSMutableDictionary *associatedDictionary = [[NSMutableDictionary alloc] init];
+        [SPDYMetadata setMetadata:originalMetadata forAssociatedDictionary:associatedDictionary];
+    }
+
     STAssertNil(weakOriginalMetadata, nil);
-    STAssertNil(metadata, nil);
 }
 
 - (void)testAssociatedDictionarySameRef


### PR DESCRIPTION
Depending on how the NSURL loading system deallocs the protocol,
the SPDYMetadata could be released before the didFinishLoading callback
even executed, or in the middle of it. It seems that iOS 8 releases
the protocol earlier than iOS 7 did.

This change removes all the dictionary code to map identifiers to
SPDYMetadata instances and instead just associates the metadata instance
with the identifier instance. A unique identifier instance is returned
for each associated dictionary it is insert into.

As long as the NSString\* identifier is alive, the SPDYMetadata for it
will also be alive.
