### PR TITLE
Allowed uploading files more than 65536 bytes.

### DIFF
--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -840,7 +840,6 @@
 
             uint32_t bytesSent = (uint32_t)data.length;
             sendWindowSize -= bytesSent;
-            _sessionSendWindowSize -= bytesSent;
             stream.sendWindowSize -= bytesSent;
             stream.localSideClosed = dataFrame.last;
         } else {


### PR DESCRIPTION
sendWindowSize was never updated with new stream.windowSize value
