### PR TITLE
Add "Coverage" configuration with code coverage flags set.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: objective-c
 before_install:
-    - brew update
+  - brew update
+  - sudo easy_install cpp-coveralls
 script: "xcodebuild test -workspace SPDY.xcodeproj/project.xcworkspace/ -scheme SPDYUnitTests -sdk iphonesimulator"
+after_success: 
+  - cp -r ${HOME}/Library/Developer/Xcode/DerivedData/SPDY-*/Build/Intermediates/SPDY.build/Coverage-iphonesimulator/SPDYUnitTests.build/Objects-normal/*/ gcov
+  - coveralls -i SPDY
+  - rm -r gcov

--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		25959A3F1937DE3900FC9731 /* SPDYSessionManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25959A3E1937DE3900FC9731 /* SPDYSessionManagerTest.m */; };
 		5C2229591952257800CAF160 /* SPDYURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C2229581952257800CAF160 /* SPDYURLRequestTest.m */; };
 		5C2A211D19F9CA0E00D0EA76 /* SPDYLoggingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */; };
+		5C427F0F1A1C7C4D0072403D /* SPDYSenTestLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C427F0E1A1C7C4D0072403D /* SPDYSenTestLog.m */; };
 		5CF0A2C91A089BC500B6D141 /* SPDYMetadataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CF0A2C81A089BC500B6D141 /* SPDYMetadataTest.m */; };
 		5CF0A2CC1A0952D900B6D141 /* SPDYMockURLProtocolClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CF0A2CB1A0952D900B6D141 /* SPDYMockURLProtocolClient.m */; };
 		7774C1318AB029C6BCEF84D6 /* SPDYSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7774C2026A4DE9957D75F629 /* SPDYSessionTest.m */; };
@@ -150,6 +151,7 @@
 		4FE895BE087AC28BBBC857F9 /* SPDYHeaderBlockDecompressor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYHeaderBlockDecompressor.m; sourceTree = "<group>"; };
 		5C2229581952257800CAF160 /* SPDYURLRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYURLRequestTest.m; sourceTree = "<group>"; };
 		5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYLoggingTest.m; sourceTree = "<group>"; };
+		5C427F0E1A1C7C4D0072403D /* SPDYSenTestLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYSenTestLog.m; sourceTree = "<group>"; };
 		5CF0A2C81A089BC500B6D141 /* SPDYMetadataTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYMetadataTest.m; sourceTree = "<group>"; };
 		5CF0A2CA1A0952BA00B6D141 /* SPDYMockURLProtocolClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYMockURLProtocolClient.h; sourceTree = "<group>"; };
 		5CF0A2CB1A0952D900B6D141 /* SPDYMockURLProtocolClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYMockURLProtocolClient.m; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				7774C0ECD0C6E5D73FB38752 /* SPDYSocket+SPDYSocketMock.m */,
 				5CF0A2CA1A0952BA00B6D141 /* SPDYMockURLProtocolClient.h */,
 				5CF0A2CB1A0952D900B6D141 /* SPDYMockURLProtocolClient.m */,
+				5C427F0E1A1C7C4D0072403D /* SPDYSenTestLog.m */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -593,6 +596,7 @@
 				061C8E9517C5954400D22083 /* SPDYStreamManager.m in Sources */,
 				06B290CE1861018900540A03 /* SPDYOrigin.m in Sources */,
 				7774C1F1E544793907908882 /* SPDYMockFrameEncoderDelegate.m in Sources */,
+				5C427F0F1A1C7C4D0072403D /* SPDYSenTestLog.m in Sources */,
 				7774CA1FA1F4A59CA0906BB7 /* SPDYSocket+SPDYSocketMock.m in Sources */,
 				7774C1318AB029C6BCEF84D6 /* SPDYSessionTest.m in Sources */,
 			);
@@ -845,6 +849,134 @@
 			};
 			name = Release;
 		};
+		5C427F091A1C08D40072403D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"COVERAGE=1",
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Coverage;
+		};
+		5C427F0A1A1C08D40072403D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SPDYUnitTests/SPDYUnitTests-Prefix.pch";
+				INFOPLIST_FILE = "SPDYUnitTests/SPDYUnitTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Coverage;
+		};
+		5C427F0B1A1C08D40072403D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				DSTROOT = /tmp/SPDY_iphoneos.dst;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SPDY.iphoneos/SPDY.iphoneos-Prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include/SPDY;
+				SKIP_INSTALL = YES;
+				VALID_ARCHS = "armv7 armv7s arm64 x86_64 i386";
+			};
+			name = Coverage;
+		};
+		5C427F0C1A1C08D40072403D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DSTROOT = /tmp/SPDY_macosx.dst;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SPDY.macosx/SPDY.macosx-Prefix.pch";
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VALID_ARCHS = x86_64;
+			};
+			name = Coverage;
+		};
+		5C427F0D1A1C08D40072403D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)";
+				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SPDY/SPDY-Prefix.pch";
+				INFOPLIST_FILE = "SPDY/SPDY-Info.plist";
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Coverage;
+		};
 		D2CC14BB16179B43002E37CF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -904,6 +1036,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				064EFB2416715C9F002F0AEC /* Debug */,
+				5C427F0A1A1C08D40072403D /* Coverage */,
 				064EFB2516715C9F002F0AEC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -913,6 +1046,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0651EBF116F3F7C800CE44D2 /* Debug */,
+				5C427F0B1A1C08D40072403D /* Coverage */,
 				0651EBF216F3F7C800CE44D2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -922,6 +1056,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0651EC1216F3F7E500CE44D2 /* Debug */,
+				5C427F0C1A1C08D40072403D /* Coverage */,
 				0651EC1316F3F7E500CE44D2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -931,6 +1066,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0652632516F7B6360081868F /* Debug */,
+				5C427F0D1A1C08D40072403D /* Coverage */,
 				0652632616F7B6360081868F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -940,6 +1076,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D2CC14BB16179B43002E37CF /* Debug */,
+				5C427F091A1C08D40072403D /* Coverage */,
 				D2CC14BC16179B43002E37CF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDYUnitTests.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDYUnitTests.xcscheme
@@ -26,7 +26,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Coverage">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SPDYUnitTests/SPDYSenTestLog.m
+++ b/SPDYUnitTests/SPDYSenTestLog.m
@@ -1,0 +1,50 @@
+//
+//  SPDYSentTestLog.m
+//  SPDY
+//
+//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier.
+//
+// The entire point of this file is to flush the code coverage .gcda files. Apple has a bug
+// in their 7.x simulator, and possibly 8.0. At least, with Travis running 8.0, no .gcda files
+// are generated without the flush. It works fine locally using the 8.1 simulator.
+//
+// See:
+// http://www.cocoanetics.com/2013/10/xcode-coverage/
+// http://stackoverflow.com/questions/19136767/generate-gcda-files-with-xcode5-ios7-simulator-and-xctest
+// http://stackoverflow.com/questions/18394655/xcode5-code-coverage-from-cmd-line-for-ci-builds
+
+// This is defined in the "Coverage" configuration.
+#if COVERAGE
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface SPDYSentTestLog : SenTestLog
+@end
+
+// GCOV Flush function
+extern void __gcov_flush(void);
+
+@implementation SPDYSentTestLog
+
++ (void)initialize
+{
+    [[NSUserDefaults standardUserDefaults] setValue:@"SPDYSentTestLog" forKey:SenTestObserverClassKey];
+
+    [super initialize];
+}
+
++ (void)testSuiteDidStop:(NSNotification *)notification
+{
+    [super testSuiteDidStop:notification];
+
+    // workaround for missing flush with iOS 7 Simulator
+    __gcov_flush();
+}
+
+@end
+
+#endif


### PR DESCRIPTION
- new build settings
- integration with Coveralls.io when using Travis CI
- workarounds for Apple bugs

"Coverage" config is based on "Debug" but enables "Generate Test Coverage
Files" and "Instrument Program Flow" for builds. Unit tests use
this configuration now instead of Debug and also set a COVERAGE=1 flag,
for conditional use in the code.

.gcda and .gcno files are now generated, and live in
~/Library/Developer/Xcode/DerivedData/SPDY-fkxxegoemtsttmayyuvejarxgimy/Build/Intermediates/SPDY.build/Coverage-iphonesimulator/SPDYUnitTests.build/Objects-normal/i386

They can be opened with something like CoverStory locally after running
the unit tests. On Github, our integration with Travis will produce
Coveralls data for pull requests and inserts a little coverage badge.

The Travis build uses the cpp-coverage utility (coveralls) to produce
reports for Coveralls.io ingestion. This tool requires the source code and
the coverage files to be located under a common root, hence the copy into
the "gcov" directory. Finding the location where Xcode puts the
intermediate files is non-trivial, so we take advantage of the fact
Travis gives us a clean slate each time.

SPDYSenTestLog.m is created to workaround a bug where no .gcda files
are generated for certain combinations unless they are explicitly
flushed. It's unclear exactly when this happens, but simulator 7.0 is
affected, and simulator 8.0 with Travis is affected.
