### PR TITLE
Remove invalid assert.

### DIFF
--- a/SPDY/SPDYSocket.m
+++ b/SPDY/SPDYSocket.m
@@ -1545,8 +1545,6 @@ static void SPDYSocketCFWriteStreamCallback(CFWriteStreamRef stream, CFStreamEve
 {
     CHECK_THREAD_SAFETY();
 
-    NSParameterAssert(data.length > 0);
-
     if (data == nil || data.length == 0) return;
     if (_flags & kForbidReadsWrites) return;
 


### PR DESCRIPTION
In the case of data being written from an NSStream it is impossible to know the final frame until we read it. This assert sits in the valid code path that is responsible for handling the final frame.
