### PR TITLE
fix SPDY headers so dependent projects can stop using pch files

### DIFF
--- a/SPDY/SPDYError.h
+++ b/SPDY/SPDYError.h
@@ -9,10 +9,12 @@
 //  Created by Michael Schore and Jeffrey Pinner.
 //
 
-extern NSString *const SPDYStreamErrorDomain;
-extern NSString *const SPDYSessionErrorDomain;
-extern NSString *const SPDYCodecErrorDomain;
-extern NSString *const SPDYSocketErrorDomain;
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXTERN NSString *const SPDYStreamErrorDomain;
+FOUNDATION_EXTERN NSString *const SPDYSessionErrorDomain;
+FOUNDATION_EXTERN NSString *const SPDYCodecErrorDomain;
+FOUNDATION_EXTERN NSString *const SPDYSocketErrorDomain;
 
 // These errors map one-to-one with the status code in a RST_STREAM message.
 typedef enum {

--- a/SPDY/SPDYLogger.h
+++ b/SPDY/SPDYLogger.h
@@ -9,6 +9,8 @@
 //  Created by Michael Schore and Jeffrey Pinner.
 //
 
+#import <Foundation/Foundation.h>
+
 typedef enum {
     SPDYLogLevelDisabled = -1,
     SPDYLogLevelError = 0,


### PR DESCRIPTION
when attempting to build our project that depends upon
CocoaSPDY without precompiled headers, we found a 
couple of errors:
- SPDYError.h refers to NSString
  - solution: import Foundation.h
- SPDYError.h has externs that could be in C, C++ or Objective-C code
  - solution: use FOUNDATION_IMPORT, found in Foundation.h
- SPDYLogger.h refers to NSString
  - solution: import Foundation.h