### PR TITLE
Fix proxy when config is invalid.

### DIFF
--- a/SPDY/SPDYOriginEndpointManager.h
+++ b/SPDY/SPDYOriginEndpointManager.h
@@ -15,10 +15,11 @@
 @interface SPDYOriginEndpointManager : NSObject
 
 @property (nonatomic, readonly) SPDYOrigin *origin;
+@property (nonatomic, readonly) SPDYOriginEndpoint *endpoint;
 @property (nonatomic, readonly) NSUInteger remaining;
 
 - (id)initWithOrigin:(SPDYOrigin *)origin;
 - (void)resolveEndpointsWithCompletionHandler:(void (^)())completionHandler;
-- (SPDYOriginEndpoint *)selectNextEndpoint;
+- (SPDYOriginEndpoint *)moveToNextEndpoint;
 
 @end

--- a/SPDYUnitTests/SPDYMockOriginEndpointManager.h
+++ b/SPDYUnitTests/SPDYMockOriginEndpointManager.h
@@ -12,6 +12,6 @@
 #import "SPDYOriginEndpointManager.h"
 
 @interface SPDYMockOriginEndpointManager : SPDYOriginEndpointManager
-@property NSArray *mock_proxyList;
+@property (nonatomic) NSArray *mock_proxyList;
+@property (nonatomic) NSString *mock_autoConfigScript;
 @end
-

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
@@ -47,8 +47,8 @@ SPDYFrameDecoder *socketMock_frameDecoder = nil;
     // autorelease pool at this point, so avoid Objective-C calls.
     Method original, swizzle;
 
-    original = class_getInstanceMethod(self, @selector(connectToHost:onPort:withTimeout:error:));
-    swizzle = class_getInstanceMethod(self, @selector(swizzled_connectToHost:onPort:withTimeout:error:));
+    original = class_getInstanceMethod(self, @selector(connectToOrigin:withTimeout:error:));
+    swizzle = class_getInstanceMethod(self, @selector(swizzled_connectToOrigin:withTimeout:error:));
     if (performSwizzling) {
         method_exchangeImplementations(original, swizzle);
     } else {
@@ -72,12 +72,11 @@ SPDYFrameDecoder *socketMock_frameDecoder = nil;
     }
 }
 
-- (BOOL)swizzled_connectToHost:(NSString *)hostname
-                        onPort:(in_port_t)port
-                   withTimeout:(NSTimeInterval)timeout
-                         error:(NSError **)pError
+- (bool)swizzled_connectToOrigin:(SPDYOrigin *)origin
+                     withTimeout:(NSTimeInterval)timeout
+                           error:(NSError **)pError
 {
-    NSLog(@"SPDYMock: Swizzled connectToHost:%@ onPost:%d withTimeout:%f", hostname, port, timeout);
+    NSLog(@"SPDYMock: Swizzled connectToOrigin:%@ withTimeout:%f error", origin, timeout);
 
     return YES;
 }


### PR DESCRIPTION
If an auto-config .pac file specifies a SOCKS proxy, or has a typo,
or a manually configured proxy has no values, or any other case where
we end up with no available proxies, we should fall back to using a
direct connection.

In addition, within the connectToOrigin code in SPDYSocket, if the
connection fails on the first call (using a manually configured proxy
or something invalid happens setting up the streams), then it's
important to return NO to the session. Since the delegate hasn't been
set yet in the session, always returning YES could result in a zombie
session being inserted into the pool and remaining there indefinitely.

More unit tests for endpoint manager and socket, and some refactoring.
Fixed some test logic.