### PR TITLE
Support for multiple proxies and reporting of status

### DIFF
--- a/SPDY/SPDYError.h
+++ b/SPDY/SPDYError.h
@@ -52,3 +52,15 @@ typedef enum {
     SPDYSocketTransportError,
     SPDYSocketProxyError
 } SPDYSocketError;
+
+typedef enum {
+    SPDYProxyStatusNone = 0,        // direct connection
+    SPDYProxyStatusManual,          // manually configured HTTPS proxy
+    SPDYProxyStatusManualInvalid,   // manually configured proxy but not supported
+    SPDYProxyStatusManualWithAuth,  // manually configured HTTPS proxy that needs auth
+    SPDYProxyStatusAuto,            // proxy auto-config URL, resolved to 1 or more HTTPS proxies
+    SPDYProxyStatusAutoInvalid,     // proxy auto-config URL, did not resolve to supported HTTPS proxy
+    SPDYProxyStatusAutoWithAuth,    // proxy auto-config URL, resolved to 1 or more HTTPS proxies needing auth
+    SPDYProxyStatusConfig,          // info provided in SPDYConfiguration, not from system
+    SPDYProxyStatusConfigWithAuth   // info provided in SPDYConfiguration, proxy needs auth
+} SPDYProxyStatus;

--- a/SPDY/SPDYMetadata.h
+++ b/SPDY/SPDYMetadata.h
@@ -25,6 +25,7 @@
 @property (nonatomic, copy) NSString *hostAddress;
 @property (nonatomic) NSUInteger hostPort;
 @property (nonatomic) BOOL viaProxy;
+@property (nonatomic) SPDYProxyStatus proxyStatus;
 
 - (NSDictionary *)dictionary;
 

--- a/SPDY/SPDYMetadata.m
+++ b/SPDY/SPDYMetadata.m
@@ -52,6 +52,7 @@ static NSString * const SPDYMetadataIdentifierKey = @"x-spdy-metadata-identifier
         SPDYMetadataStreamConnectedMsKey : [@(_connectedMs) stringValue],
         SPDYMetadataStreamBlockedMsKey : [@(_blockedMs) stringValue],
         SPDYMetadataSessionViaProxyKey : [@(_viaProxy) stringValue],
+        SPDYMetadataSessionProxyStatusKey : [@(_proxyStatus) stringValue],
     }];
 
     if (_streamId > 0) {

--- a/SPDY/SPDYOriginEndpointManager.h
+++ b/SPDY/SPDYOriginEndpointManager.h
@@ -20,7 +20,7 @@
 @property (nonatomic, readonly) SPDYOriginEndpoint *endpoint;
 @property (nonatomic, readonly) NSUInteger remaining;
 @property (nonatomic, readonly) SPDYProxyStatus proxyStatus;
-@property (nonatomic) BOOL authRequired;  // writable since only the socket knows the answer
+@property (nonatomic) bool authRequired;  // writable since only the socket knows the answer
 
 - (id)initWithOrigin:(SPDYOrigin *)origin;
 - (void)resolveEndpointsWithCompletionHandler:(void (^)())completionHandler;

--- a/SPDY/SPDYOriginEndpointManager.h
+++ b/SPDY/SPDYOriginEndpointManager.h
@@ -9,6 +9,8 @@
 //  Created by Kevin Goodier
 //
 
+#import "SPDYError.h"
+
 @class SPDYOrigin;
 @class SPDYOriginEndpoint;
 
@@ -17,6 +19,8 @@
 @property (nonatomic, readonly) SPDYOrigin *origin;
 @property (nonatomic, readonly) SPDYOriginEndpoint *endpoint;
 @property (nonatomic, readonly) NSUInteger remaining;
+@property (nonatomic, readonly) SPDYProxyStatus proxyStatus;
+@property (nonatomic) BOOL authRequired;  // writable since only the socket knows the answer
 
 - (id)initWithOrigin:(SPDYOrigin *)origin;
 - (void)resolveEndpointsWithCompletionHandler:(void (^)())completionHandler;

--- a/SPDY/SPDYOriginEndpointManager.m
+++ b/SPDY/SPDYOriginEndpointManager.m
@@ -66,7 +66,7 @@
     }
 }
 
-- (void)setAuthRequired:(BOOL)authRequired
+- (void)setAuthRequired:(bool)authRequired
 {
     _authRequired = authRequired;
     switch (_proxyStatus) {

--- a/SPDY/SPDYOriginEndpointManager.m
+++ b/SPDY/SPDYOriginEndpointManager.m
@@ -14,6 +14,7 @@
 #endif
 
 #import "SPDYCommonLogger.h"
+#import "SPDYError.h"
 #import "SPDYOrigin.h"
 #import "SPDYOriginEndpoint.h"
 #import "SPDYOriginEndpointManager.h"
@@ -65,6 +66,24 @@
     }
 }
 
+- (void)setAuthRequired:(BOOL)authRequired
+{
+    _authRequired = authRequired;
+    switch (_proxyStatus) {
+        case SPDYProxyStatusManual:
+            _proxyStatus = SPDYProxyStatusManualWithAuth;
+            break;
+        case SPDYProxyStatusAuto:
+            _proxyStatus = SPDYProxyStatusAutoWithAuth;
+            break;
+        case SPDYProxyStatusConfig:
+            _proxyStatus = SPDYProxyStatusConfigWithAuth;
+            break;
+        default:
+            SPDY_WARNING(@"unexpected endpoint state, can't set auth required for SPDYProxyStatus %d", (int)_proxyStatus);
+    }
+}
+
 - (void)resolveEndpointsWithCompletionHandler:(void (^)())completionHandler
 {
     _resolveCallback = [completionHandler copy];
@@ -81,6 +100,7 @@
                                                            type:SPDYOriginEndpointTypeHttpsProxy
                                                          origin:_origin];
             [_endpointList addObject:endpoint];
+            _proxyStatus = SPDYProxyStatusConfig;
         } else {
             // Use system configuration
             NSArray *originalProxyList = [self _proxyGetListFromSettings:[self _proxyGetSystemSettings]];
@@ -174,6 +194,7 @@
 {
     if (error) {
         SPDY_ERROR(@"Error executing auto-config proxy URL: %@", error);
+        _proxyStatus = SPDYProxyStatusAutoInvalid;
     } else if (proxies) {
         [self _proxyAddSupportedFrom:proxies executeAutoConfig:NO];
     }
@@ -249,6 +270,9 @@ static void ResultCallback(void* client, CFArrayRef proxies, CFErrorRef error)
                                                          origin:_origin];
             [_endpointList addObject:endpoint];
             SPDY_INFO(@"Proxy: added endpoint %@", endpoint);
+            if (_proxyStatus == SPDYProxyStatusNone) {
+                _proxyStatus = SPDYProxyStatusManual;
+            }
         } else if ([proxyType isEqualToString:(__bridge NSString *)kCFProxyTypeNone]) {
             SPDYOriginEndpoint *endpoint;
             endpoint = [[SPDYOriginEndpoint alloc] initWithHost:_origin.host
@@ -262,9 +286,18 @@ static void ResultCallback(void* client, CFArrayRef proxies, CFErrorRef error)
         } else if ([proxyType isEqualToString:(__bridge NSString *)kCFProxyTypeAutoConfigurationURL] && executeAutoConfig) {
             NSURL *pacScriptUrl = proxyDict[(__bridge NSString *) kCFProxyAutoConfigurationURLKey];
             SPDY_INFO(@"Proxy: executing auto-config url: %@", pacScriptUrl);
+            _proxyStatus = SPDYProxyStatusAuto;
             [self _proxyExecuteAutoConfigURL:pacScriptUrl];
         } else {
             SPDY_INFO(@"Proxy: ignoring unsupported endpoint %@:%d (%@)", host, port, proxyType);
+        }
+    }
+
+    if (_endpointList.count == 0) {
+        if (_proxyStatus == SPDYProxyStatusAuto) {
+            _proxyStatus = SPDYProxyStatusAutoInvalid;
+        } else {
+            _proxyStatus = SPDYProxyStatusManualInvalid;
         }
     }
 }

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -33,6 +33,9 @@ extern NSString *const SPDYMetadataSessionRemotePortKey;
 // Indicates connection used a proxy server
 extern NSString *const SPDYMetadataSessionViaProxyKey;
 
+// Indicates state of proxy configuration. See SPDYProxyStatus in SPDYError.h.
+extern NSString *const SPDYMetadataSessionProxyStatusKey;
+
 // SPDY session latency, in milliseconds, as measured by pings, e.g. "150"
 extern NSString *const SPDYMetadataSessionLatencyKey;
 

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -35,6 +35,7 @@ NSString *const SPDYMetadataVersionKey = @"x-spdy-version";
 NSString *const SPDYMetadataSessionRemoteAddressKey = @"x-spdy-session-remote-address";
 NSString *const SPDYMetadataSessionRemotePortKey = @"x-spdy-session-remote-port";
 NSString *const SPDYMetadataSessionViaProxyKey = @"x-spdy-session-via-proxy";
+NSString *const SPDYMetadataSessionProxyStatusKey = @"x-spdy-session-proxy-status";
 NSString *const SPDYMetadataSessionLatencyKey = @"x-spdy-session-latency";
 NSString *const SPDYMetadataStreamBlockedMsKey = @"x-spdy-stream-blocked-ms";
 NSString *const SPDYMetadataStreamConnectedMsKey = @"x-spdy-stream-connected-ms";

--- a/SPDY/SPDYSocket.h
+++ b/SPDY/SPDYSocket.h
@@ -201,6 +201,11 @@ extern NSString *const SPDYSocketException;
 - (in_port_t)connectedPort;
 
 /**
+  @return YES if the socket has been closed after attempting to connect
+*/
+- (bool)closed;
+
+/**
   @return YES if the socket is IPv4
 */
 - (bool)isIPv4;

--- a/SPDY/SPDYSocket.m
+++ b/SPDY/SPDYSocket.m
@@ -1838,6 +1838,7 @@ static void SPDYSocketCFWriteStreamCallback(CFWriteStreamRef stream, CFStreamEve
             [self _scheduleWrite];
         } else if ([proxyReadOp needsAuth]) {
             SPDY_ERROR(@"socket failed proxy connection to %@ (auth required), got \"%@\"", _endpoint, proxyReadOp);
+            _endpointManager.authRequired = YES;
             [self _attemptNextProxyConnectionForError:SPDY_SOCKET_ERROR(SPDYSocketProxyError, @"Authentication required (not supported)")];
         } else {
             SPDY_ERROR(@"socket failed proxy connection to %@, got \"%@\"", _endpoint, proxyReadOp);

--- a/SPDY/SPDYSocketOps.h
+++ b/SPDY/SPDYSocketOps.h
@@ -61,6 +61,7 @@
 - (id)initWithTimeout:(NSTimeInterval)timeout;
 - (bool)tryParseResponse;
 - (bool)success;
+- (bool)needsAuth;
 
 @end
 

--- a/SPDY/SPDYSocketOps.m
+++ b/SPDY/SPDYSocketOps.m
@@ -153,25 +153,12 @@
 
 - (bool)success
 {
-    if (![_version isEqualToString:@"HTTP/1.0"] && ![_version isEqualToString:@"HTTP/1.1"]) {
-        return NO;
-    }
-    if (_statusCode < 200 || _statusCode >= 300) {
-        return NO;
-    }
-    return YES;
+    return _statusCode >= 200 && _statusCode < 300 && [_version hasPrefix:@"HTTP/1"];
 }
 
 - (bool)needsAuth
 {
-    if (![_version isEqualToString:@"HTTP/1.0"] && ![_version isEqualToString:@"HTTP/1.1"]) {
-        return NO;
-    }
-    if (_statusCode != 407) {
-        return NO;
-    }
-    // TODO: check for "Proxy-Authenticate" header
-    return YES;
+    return _statusCode == 407 && [_version hasPrefix:@"HTTP/1"];
 }
 
 - (NSString *)description

--- a/SPDY/SPDYSocketOps.m
+++ b/SPDY/SPDYSocketOps.m
@@ -162,6 +162,18 @@
     return YES;
 }
 
+- (bool)needsAuth
+{
+    if (![_version isEqualToString:@"HTTP/1.0"] && ![_version isEqualToString:@"HTTP/1.1"]) {
+        return NO;
+    }
+    if (_statusCode != 407) {
+        return NO;
+    }
+    // TODO: check for "Proxy-Authenticate" header
+    return YES;
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:

--- a/SPDYUnitTests/SPDYMetadataTest.m
+++ b/SPDYUnitTests/SPDYMetadataTest.m
@@ -41,6 +41,7 @@
     metadata.hostAddress = @"1.2.3.4";
     metadata.hostPort = 1;
     metadata.viaProxy = YES;
+    metadata.proxyStatus = SPDYProxyStatusManual;
 
     return metadata;
 }
@@ -62,6 +63,7 @@
     STAssertNil(dict[SPDYMetadataSessionRemoteAddressKey], nil);
     STAssertNil(dict[SPDYMetadataSessionRemotePortKey], nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionViaProxyKey], @"0", nil);
+    STAssertEqualObjects(dict[SPDYMetadataSessionProxyStatusKey], @"0", nil);
 }
 
 - (void)testSerializeToDictionary
@@ -79,6 +81,7 @@
     STAssertEqualObjects(dict[SPDYMetadataSessionRemoteAddressKey], @"1.2.3.4", nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionRemotePortKey], @"1", nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionViaProxyKey], @"1", nil);
+    STAssertEqualObjects(dict[SPDYMetadataSessionProxyStatusKey], @"1", nil);
 }
 
 - (void)testMemberRetention

--- a/SPDYUnitTests/SPDYSocketOpsTest.m
+++ b/SPDYUnitTests/SPDYSocketOpsTest.m
@@ -102,8 +102,6 @@
             @"HTTP/1.1 300 Foo\r\n\r\n",
             @"HTTP/1.1 400 Foo\r\n\r\n",
             @"HTTP/1.1 500 Error\r\n\r\n",
-            @"HTTP/1 200 Connection established\r\n\r\n",
-            @"HTTP/1.2 200 Connection established\r\n\r\n",
             @"/1.1 200 Connection established\r\n\r\n",
             @"1.1 200 Connection established\r\n\r\n",
             @"GARBAGE 200 Connection established\r\n\r\n",
@@ -130,6 +128,8 @@
             @"HTTP/1.1 200 Connection established\r\nHeader: Foo\r\nHeader2: Foo Bar\r\n\r\n",
             @"HTTP/1.1 200.1 Connection established\r\n\r\n",
             @"HTTP/1.1 200 Connection established\r\n\r\n",
+            @"HTTP/1 200 Connection established\r\n\r\n", // questionable
+            @"HTTP/1.2 200 Connection established\r\n\r\n", // questionable
             ];
 
     for (NSString *responseStr in responseStrList) {

--- a/SPDYUnitTests/SPDYSocketTest.m
+++ b/SPDYUnitTests/SPDYSocketTest.m
@@ -14,6 +14,10 @@
 #import "SPDYSocket.h"
 #import "SPDYSocketOps.h"
 
+@interface SPDYSocket ()
+- (void)_onProxyResponse:(SPDYSocketProxyReadOp *)proxyReadOp;
+@end
+
 @interface SPDYMockSocket : SPDYSocket
 @property (nonatomic, readonly) NSString *createStreamsToHostname;
 @property (nonatomic, readonly) in_port_t createStreamsToPort;
@@ -24,6 +28,23 @@
 
 @implementation SPDYMockSocket
 {
+}
+
+- (void)mockProxyResponse:(NSString *)responseString
+{
+    NSMutableArray *readQueue = [self readQueue];
+    [self setValue:[readQueue objectAtIndex:0] forKey:@"_currentReadOp"];
+    [readQueue removeObjectAtIndex:0];
+
+    NSMutableArray *writeQueue = [self writeQueue];
+    [self setValue:[writeQueue objectAtIndex:0] forKey:@"_currentWriteOp"];
+    [writeQueue removeObjectAtIndex:0];
+
+    SPDYSocketProxyReadOp *proxyReadOp = [self valueForKey:@"_currentReadOp"];
+    NSData *responseData = [responseString dataUsingEncoding:NSUTF8StringEncoding];
+    [proxyReadOp->_buffer setData:responseData];
+    proxyReadOp->_bytesRead = responseData.length;
+    [self _onProxyResponse:proxyReadOp];
 }
 
 - (NSMutableArray *)readQueue
@@ -64,8 +85,10 @@
 {
     if (_openStreamsShouldFail) {
         *pError = [NSError errorWithDomain:@"UnitTest" code:1 userInfo:nil];
+        _openStreamsShouldFail = NO;
+        return NO;
     }
-    return !_openStreamsShouldFail;
+    return YES;
 }
 
 - (void)_scheduleRead
@@ -90,9 +113,23 @@
 
 @property (nonatomic) BOOL shouldFailWillConnect;
 @property (nonatomic) BOOL shouldStopRunLoop;
+
+- (void)reset;
+
 @end
 
 @implementation SPDYMockSocketDelegate
+
+- (void)reset
+{
+    _didCallWillDisconnectWithError = NO;
+    _didCallDidDisconnect = NO;
+    _didCallWillConnect = NO;
+    _didCallDidConnectToEndpoint = NO;
+    _lastError = nil;
+    _shouldFailWillConnect = NO;
+    _shouldStopRunLoop = NO;
+}
 
 - (void)socket:(SPDYSocket *)socket willDisconnectWithError:(NSError *)error
 {
@@ -143,12 +180,7 @@
     NSError *error = nil;
     SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:@"https://mytesthost.com:443" error:&error];
     SPDYMockOriginEndpointManager *manager = [[SPDYMockOriginEndpointManager alloc] initWithOrigin:origin];
-
-    manager.mock_proxyList = @[@{
-            (__bridge NSString *)kCFProxyTypeKey : (__bridge NSString *)kCFProxyTypeHTTPS,
-            (__bridge NSString *)kCFProxyHostNameKey : @"1.2.3.4",
-            (__bridge NSString *)kCFProxyPortNumberKey : @"8888"
-    }];
+    manager.mock_proxyList = proxyList;
 
     // Set up mocked socket
     SPDYMockSocket *socket = [[SPDYMockSocket alloc] initWithDelegate:delegate endpointManager:manager];
@@ -173,11 +205,26 @@
     STAssertTrue(socket.didCallScheduleRead, nil);
     STAssertTrue(socket.didCallScheduleWrite, nil);
 
-    STAssertEqualObjects(socket.createStreamsToHostname, @"1.2.3.4", nil);
-    STAssertEquals(socket.createStreamsToPort, (in_port_t)8888, nil);
+    STAssertEqualObjects(socket.createStreamsToHostname, host, nil);
+    STAssertEquals(socket.createStreamsToPort, (in_port_t)port, nil);
 
-    STAssertTrue([[[socket readQueue] objectAtIndex:0] isKindOfClass:[SPDYSocketProxyReadOp class]], nil);
-    STAssertTrue([[[socket writeQueue] objectAtIndex:0] isKindOfClass:[SPDYSocketProxyWriteOp class]], nil);
+    STAssertTrue([[[socket readQueue] firstObject] isKindOfClass:[SPDYSocketProxyReadOp class]], nil);
+    STAssertTrue([[[socket writeQueue] firstObject] isKindOfClass:[SPDYSocketProxyWriteOp class]], nil);
+}
+
+- (void)_assertDirectConnectWasInitiatedForSocket:(SPDYMockSocket *)socket
+{
+    SPDYMockSocketDelegate *socketDelegate = socket.delegate;
+    STAssertTrue(socketDelegate.didCallWillConnect, nil);
+    STAssertFalse(socketDelegate.didCallWillDisconnectWithError, nil);
+    STAssertFalse(socketDelegate.didCallDidDisconnect, nil);
+    STAssertFalse(socketDelegate.didCallDidConnectToEndpoint, nil);
+
+    STAssertEqualObjects(socket.createStreamsToHostname, @"mytesthost.com", nil);
+    STAssertEquals(socket.createStreamsToPort, (in_port_t)443, nil);
+
+    STAssertEquals([[socket readQueue] count], (NSUInteger)0, nil);
+    STAssertEquals([[socket writeQueue] count], (NSUInteger)0, nil);
 }
 
 #pragma mark Tests
@@ -206,7 +253,6 @@
             (__bridge NSString *)kCFProxyPortNumberKey : @"8888"
     }] delegate:socketDelegate];
 
-    STAssertTrue(socket.connectedToProxy, nil);
     STAssertTrue(socketDelegate.didCallWillConnect, nil);
     STAssertTrue(socketDelegate.didCallWillDisconnectWithError, nil);
     STAssertTrue(socketDelegate.didCallDidDisconnect, nil);
@@ -271,5 +317,48 @@
     STAssertFalse(socket.connectedToProxy, nil);
 }
 
-@end
+- (void)testConnectWithProxyAndFallbackDoesConnectToDirectWhenProxyFailsOpenStream
+{
+    // Set up mock origin endpoint manager to avoid getting system's real proxy config.
+    NSError *error = nil;
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:@"https://mytesthost.com:443" error:&error];
+    SPDYMockOriginEndpointManager *manager = [[SPDYMockOriginEndpointManager alloc] initWithOrigin:origin];
 
+    manager.mock_proxyList = @[@{
+            (__bridge NSString *)kCFProxyTypeKey : (__bridge NSString *)kCFProxyTypeHTTPS,
+            (__bridge NSString *)kCFProxyHostNameKey : @"1.2.3.4",
+            (__bridge NSString *)kCFProxyPortNumberKey : @"8888"
+    }, @{
+            (__bridge NSString *)kCFProxyTypeKey : (__bridge NSString *)kCFProxyTypeNone,
+    }];
+
+    // Set up mocked socket
+    SPDYMockSocketDelegate *socketDelegate = [[SPDYMockSocketDelegate alloc] init];
+
+    SPDYMockSocket *socket = [[SPDYMockSocket alloc] initWithDelegate:socketDelegate endpointManager:manager];
+    socket.openStreamsShouldFail = YES;
+    STAssertTrue([socket connectToOrigin:origin withTimeout:(NSTimeInterval)-1 error:&error], nil);
+    STAssertNil(error, nil);
+    [self _assertDirectConnectWasInitiatedForSocket:socket];
+}
+
+- (void)testConnectWithProxyAndFallbackDoesConnectToDirectWhenProxyFailsConnectResponse
+{
+    SPDYMockSocket *socket = [self _createConnectedSocketWithProxyList:@[@{
+            (__bridge NSString *)kCFProxyTypeKey : (__bridge NSString *)kCFProxyTypeHTTPS,
+            (__bridge NSString *)kCFProxyHostNameKey : @"1.2.3.4",
+            (__bridge NSString *)kCFProxyPortNumberKey : @"8888"
+    }, @{
+            (__bridge NSString *)kCFProxyTypeKey : (__bridge NSString *)kCFProxyTypeNone,
+    }]];
+
+    STAssertTrue(socket.connectedToProxy, nil);
+    [self _assertProxyConnectWasInitiatedToHost:@"1.2.3.4" port:8888 socket:socket];
+
+    SPDYMockSocketDelegate *delegate = socket.delegate;
+    [delegate reset];
+    [socket mockProxyResponse:@"HTTP/1.1 500 Not ok\r\n\r\n"];
+    [self _assertDirectConnectWasInitiatedForSocket:socket];
+}
+
+@end


### PR DESCRIPTION
This adds support for multiple proxies, which can be configured via a .pac file. It also adds support for fallback-to-direct in all cases, which maximizes backwards compatibility but veers a little bit from normal NSURL system behavior. 

Proxies requiring authentication are still not supported, but the socket will fall back to a direct connection.

This change also includes metadata that indicates information about the proxy config and what the socket is doing and why.