### PR TITLE
Increase test code coverage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # CocoaSPDY
 #### A SPDY/3.1 framework for iOS and Mac OS X
 
-[![Build Status](https://travis-ci.org/twitter/CocoaSPDY.png?branch=master)](https://travis-ci.org/twitter/CocoaSPDY)
+Branch | Build | Code Coverage
+------ | ----- | -------------
+master | [![Build Status](https://travis-ci.org/twitter/CocoaSPDY.png?branch=master)](https://travis-ci.org/twitter/CocoaSPDY) | [![Coverage Status](https://coveralls.io/repos/twitter/CocoaSPDY/badge.png?branch=master)](https://coveralls.io/r/twitter/CocoaSPDY?branch=master) 
+develop | [![Build Status](https://travis-ci.org/twitter/CocoaSPDY.png?branch=develop)](https://travis-ci.org/twitter/CocoaSPDY) | [![Coverage Status](https://coveralls.io/repos/twitter/CocoaSPDY/badge.png?branch=develop)](https://coveralls.io/r/twitter/CocoaSPDY?branch=develop)
 
 ### [Download v1.0.2](https://github.com/twitter/CocoaSPDY/releases/download/v1.0.2/SPDY.framework.tar.gz)
 

--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -96,6 +96,9 @@
 		5C04570019B033E9009E0AC2 /* SPDYSocketOps.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C0456FE19B033E9009E0AC2 /* SPDYSocketOps.m */; };
 		5C04570319B033EA009E0AC2 /* SPDYSocketOps.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C0456FE19B033E9009E0AC2 /* SPDYSocketOps.m */; };
 		5C04570519B043CB009E0AC2 /* SPDYOriginEndpointTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C04570419B043CB009E0AC2 /* SPDYOriginEndpointTest.m */; };
+		5C210A0A1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C210A091A5F48C500ADB538 /* SPDYSessionPool.m */; };
+		5C210A0B1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C210A091A5F48C500ADB538 /* SPDYSessionPool.m */; };
+		5C210A0C1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C210A091A5F48C500ADB538 /* SPDYSessionPool.m */; };
 		5C2229591952257800CAF160 /* SPDYURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C2229581952257800CAF160 /* SPDYURLRequestTest.m */; };
 		5C2A211D19F9CA0E00D0EA76 /* SPDYLoggingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */; };
 		5C427F0F1A1C7C4D0072403D /* SPDYSenTestLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C427F0E1A1C7C4D0072403D /* SPDYSenTestLog.m */; };
@@ -114,6 +117,8 @@
 		5C9A0BD01A363BDC00CF2D3D /* SPDYOriginEndpointManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C9A0BCF1A363BDC00CF2D3D /* SPDYOriginEndpointManager.m */; };
 		5C9A0BD11A363BDC00CF2D3D /* SPDYOriginEndpointManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C9A0BCF1A363BDC00CF2D3D /* SPDYOriginEndpointManager.m */; };
 		5C9A0BD21A363BDC00CF2D3D /* SPDYOriginEndpointManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C9A0BCF1A363BDC00CF2D3D /* SPDYOriginEndpointManager.m */; };
+		5CA0B9C61A6454950068ABD9 /* SPDYProtocolTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CA0B9C51A6454950068ABD9 /* SPDYProtocolTest.m */; };
+		5CA0B9C81A6486F10068ABD9 /* SPDYSettingsStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CA0B9C71A6486F10068ABD9 /* SPDYSettingsStoreTest.m */; };
 		5CF0A2C91A089BC500B6D141 /* SPDYMetadataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CF0A2C81A089BC500B6D141 /* SPDYMetadataTest.m */; };
 		5CF0A2CC1A0952D900B6D141 /* SPDYMockURLProtocolClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CF0A2CB1A0952D900B6D141 /* SPDYMockURLProtocolClient.m */; };
 		7774C1318AB029C6BCEF84D6 /* SPDYSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7774C2026A4DE9957D75F629 /* SPDYSessionTest.m */; };
@@ -179,6 +184,8 @@
 		5C0456FC19B033D5009E0AC2 /* SPDYSocketOps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYSocketOps.h; sourceTree = "<group>"; };
 		5C0456FE19B033E9009E0AC2 /* SPDYSocketOps.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYSocketOps.m; sourceTree = "<group>"; };
 		5C04570419B043CB009E0AC2 /* SPDYOriginEndpointTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYOriginEndpointTest.m; sourceTree = "<group>"; };
+		5C210A081A5F408200ADB538 /* SPDYSessionPool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDYSessionPool.h; sourceTree = "<group>"; };
+		5C210A091A5F48C500ADB538 /* SPDYSessionPool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYSessionPool.m; sourceTree = "<group>"; };
 		5C2229581952257800CAF160 /* SPDYURLRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYURLRequestTest.m; sourceTree = "<group>"; };
 		5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYLoggingTest.m; sourceTree = "<group>"; };
 		5C427F0E1A1C7C4D0072403D /* SPDYSenTestLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYSenTestLog.m; sourceTree = "<group>"; };
@@ -192,6 +199,8 @@
 		5C6B0D281A3A3E8400334BFA /* SPDYCanonicalRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYCanonicalRequest.m; sourceTree = "<group>"; };
 		5C9A0BCB1A363B7700CF2D3D /* SPDYOriginEndpointManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYOriginEndpointManager.h; sourceTree = "<group>"; };
 		5C9A0BCF1A363BDC00CF2D3D /* SPDYOriginEndpointManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYOriginEndpointManager.m; sourceTree = "<group>"; };
+		5CA0B9C51A6454950068ABD9 /* SPDYProtocolTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYProtocolTest.m; sourceTree = "<group>"; };
+		5CA0B9C71A6486F10068ABD9 /* SPDYSettingsStoreTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYSettingsStoreTest.m; sourceTree = "<group>"; };
 		5CF0A2C81A089BC500B6D141 /* SPDYMetadataTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYMetadataTest.m; sourceTree = "<group>"; };
 		5CF0A2CA1A0952BA00B6D141 /* SPDYMockURLProtocolClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYMockURLProtocolClient.h; sourceTree = "<group>"; };
 		5CF0A2CB1A0952D900B6D141 /* SPDYMockURLProtocolClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYMockURLProtocolClient.m; sourceTree = "<group>"; };
@@ -275,8 +284,10 @@
 				5CF0A2C81A089BC500B6D141 /* SPDYMetadataTest.m */,
 				5C04570419B043CB009E0AC2 /* SPDYOriginEndpointTest.m */,
 				0679F3CE186217FC006F122E /* SPDYOriginTest.m */,
+				5CA0B9C51A6454950068ABD9 /* SPDYProtocolTest.m */,
 				25959A3E1937DE3900FC9731 /* SPDYSessionManagerTest.m */,
 				7774C2026A4DE9957D75F629 /* SPDYSessionTest.m */,
+				5CA0B9C71A6486F10068ABD9 /* SPDYSettingsStoreTest.m */,
 				5C0456F819B03278009E0AC2 /* SPDYSocketOpsTest.m */,
 				5C5EA4741A119CAB0058FB64 /* SPDYSocketTest.m */,
 				5C427F101A1D57890072403D /* SPDYStopwatchTest.m */,
@@ -397,6 +408,8 @@
 				D2CC14C41618DBF2002E37CF /* SPDYSession.m */,
 				D2CC14CC161A5826002E37CF /* SPDYSessionManager.h */,
 				D2CC14CD161A5826002E37CF /* SPDYSessionManager.m */,
+				5C210A081A5F408200ADB538 /* SPDYSessionPool.h */,
+				5C210A091A5F48C500ADB538 /* SPDYSessionPool.m */,
 				06FC94121694B92400FC95DF /* SPDYSettingsStore.h */,
 				06FC94131694B92400FC95DF /* SPDYSettingsStore.m */,
 				D2CC14CF161A9EE9002E37CF /* SPDYSocket.h */,
@@ -650,9 +663,12 @@
 			files = (
 				5C0456FF19B033E9009E0AC2 /* SPDYSocketOps.m in Sources */,
 				06FDA20616717DF100137DBD /* SPDYSocket.m in Sources */,
+				5CA0B9C81A6486F10068ABD9 /* SPDYSettingsStoreTest.m in Sources */,
+				5C210A0A1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */,
 				5C2A211D19F9CA0E00D0EA76 /* SPDYLoggingTest.m in Sources */,
 				06FDA20916717DF100137DBD /* SPDYFrame.m in Sources */,
 				06FDA20B16717DF100137DBD /* SPDYFrameDecoder.m in Sources */,
+				5CA0B9C61A6454950068ABD9 /* SPDYProtocolTest.m in Sources */,
 				0679F3CF186217FC006F122E /* SPDYOriginTest.m in Sources */,
 				06FDA20D16717DF100137DBD /* SPDYProtocol.m in Sources */,
 				06FDA20F16717DF100137DBD /* SPDYSession.m in Sources */,
@@ -713,6 +729,7 @@
 				0651EC4616F3FA1400CE44D2 /* SPDYStream.m in Sources */,
 				062EA643175D4CD3003BC1CE /* SPDYCommonLogger.m in Sources */,
 				061C8E9617C5954400D22083 /* SPDYStreamManager.m in Sources */,
+				5C210A0B1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */,
 				06B290CF1861018A00540A03 /* SPDYOrigin.m in Sources */,
 				5C04570019B033E9009E0AC2 /* SPDYSocketOps.m in Sources */,
 				7774C868441241542B0A90C0 /* SPDYStopwatch.m in Sources */,
@@ -741,6 +758,7 @@
 				0651EC2C16F3FA0B00CE44D2 /* SPDYStream.m in Sources */,
 				062EA645175D4CD3003BC1CE /* SPDYCommonLogger.m in Sources */,
 				061C8E9817C5954400D22083 /* SPDYStreamManager.m in Sources */,
+				5C210A0C1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */,
 				06B290D21861018A00540A03 /* SPDYOrigin.m in Sources */,
 				5C04570319B033EA009E0AC2 /* SPDYSocketOps.m in Sources */,
 				7774CDD84A5D07F8DE5B8684 /* SPDYStopwatch.m in Sources */,

--- a/SPDY/NSURLRequest+SPDYURLRequest.m
+++ b/SPDY/NSURLRequest+SPDYURLRequest.m
@@ -121,19 +121,9 @@
 
 @implementation NSMutableURLRequest (SPDYURLRequest)
 
-- (NSUInteger)SPDYPriority
-{
-    return [[SPDYProtocol propertyForKey:@"SPDYPriority" inRequest:self] unsignedIntegerValue];
-}
-
 - (void)setSPDYPriority:(NSUInteger)priority
 {
     [SPDYProtocol setProperty:@(priority) forKey:@"SPDYPriority" inRequest:self];
-}
-
-- (NSTimeInterval)SPDYDeferrableInterval
-{
-    return [[SPDYProtocol propertyForKey:@"SPDYDeferrableInterval" inRequest:self] doubleValue];
 }
 
 - (void)setSPDYDeferrableInterval:(NSTimeInterval)deferrableInterval
@@ -141,19 +131,9 @@
     [SPDYProtocol setProperty:@(deferrableInterval) forKey:@"SPDYDeferrableInterval" inRequest:self];
 }
 
-- (BOOL)SPDYBypass
-{
-    return [[SPDYProtocol propertyForKey:@"SPDYBypass" inRequest:self] boolValue];
-}
-
 - (void)setSPDYBypass:(BOOL)bypass
 {
     [SPDYProtocol setProperty:@(bypass) forKey:@"SPDYBypass" inRequest:self];
-}
-
-- (NSInputStream *)SPDYBodyStream
-{
-    return [SPDYProtocol propertyForKey:@"SPDYBodyStream" inRequest:self];
 }
 
 - (void)setSPDYBodyStream:(NSInputStream *)SPDYBodyStream
@@ -163,11 +143,6 @@
     } else {
         [SPDYProtocol setProperty:SPDYBodyStream forKey:@"SPDYBodyStream" inRequest:self];
     }
-}
-
-- (NSString *)SPDYBodyFile
-{
-    return [SPDYProtocol propertyForKey:@"SPDYBodyFile" inRequest:self];
 }
 
 - (void)setSPDYBodyFile:(NSString *)SPDYBodyFile

--- a/SPDY/SPDYSessionManager.h
+++ b/SPDY/SPDYSessionManager.h
@@ -11,11 +11,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class SPDYConfiguration;
-@class SPDYSession;
-@class SPDYStreamManager;
+@protocol SPDYSessionDelegate;
 
-@interface SPDYSessionManager : NSObject
+@interface SPDYSessionManager : NSObject <SPDYSessionDelegate>
 
 + (SPDYSessionManager *)localManagerForOrigin:(SPDYOrigin *)origin;
 - (void)queueStream:(SPDYStream *)stream;

--- a/SPDY/SPDYSessionPool.h
+++ b/SPDY/SPDYSessionPool.h
@@ -1,0 +1,29 @@
+//
+//  SPDYSessionPool.h
+//  SPDY
+//
+//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SPDYSession;
+@class SPDYSessionManager;
+
+@interface SPDYSessionPool : NSObject
+
+@property (nonatomic, assign, readonly) NSUInteger count;
+@property (nonatomic, assign) NSUInteger pendingCount;
+
+- (id)initWithOrigin:(SPDYOrigin *)origin manager:(SPDYSessionManager *)manager cellular:(bool)cellular error:(NSError **)pError;
+- (bool)contains:(SPDYSession *)session;
+- (void)add:(SPDYSession *)session;
+- (NSUInteger)count;
+- (NSUInteger)remove:(SPDYSession *)session;
+- (SPDYSession *)nextSession;
+
+@end

--- a/SPDY/SPDYSessionPool.m
+++ b/SPDY/SPDYSessionPool.m
@@ -1,0 +1,97 @@
+//
+//  SPDYSessionPool.m
+//  SPDY
+//
+//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier.
+//
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+#import "SPDYProtocol.h"
+#import "SPDYSession.h"
+#import "SPDYSessionManager.h"
+#import "SPDYSessionPool.h"
+#import "SPDYStream.h"
+
+@implementation SPDYSessionPool
+{
+    NSMutableArray *_sessions;
+}
+
+- (id)initWithOrigin:(SPDYOrigin *)origin manager:(SPDYSessionManager *)manager cellular:(bool)cellular error:(NSError **)pError
+{
+    self = [super init];
+    if (self) {
+        SPDYConfiguration *configuration = [SPDYProtocol currentConfiguration];
+        NSUInteger size = configuration.sessionPoolSize;
+        _pendingCount = size;
+        _sessions = [[NSMutableArray alloc] initWithCapacity:size];
+        for (NSUInteger i = 0; i < size; i++) {
+            SPDYSession *session = [[SPDYSession alloc] initWithOrigin:origin
+                                                              delegate:manager
+                                                         configuration:configuration
+                                                              cellular:cellular
+                                                                 error:pError];
+            if (!session) {
+                return nil;
+            }
+            [_sessions addObject:session];
+        }
+    }
+    return self;
+}
+
+- (bool)contains:(SPDYSession *)session
+{
+    return [_sessions containsObject:session];
+}
+
+- (void)add:(SPDYSession *)session
+{
+    [_sessions addObject:session];
+}
+
+- (NSUInteger)count
+{
+    return _sessions.count;
+}
+
+- (NSUInteger)remove:(SPDYSession *)session
+{
+    [_sessions removeObject:session];
+    return _sessions.count;
+}
+
+- (SPDYSession *)nextSession
+{
+    SPDYSession *session;
+
+    if (_sessions.count == 0) {
+        return nil;
+    }
+
+    session = _sessions[0];
+    NSAssert(session.isOpen, @"Should never contain closed sessions.");
+
+    // TODO: clean this up
+    while (!session.isOpen) {
+        if ([self remove:session] == 0) return nil;
+        session = _sessions[0];
+    }
+
+    // Rotate
+    if (_sessions.count > 1) {
+        [_sessions removeObjectAtIndex:0];
+        [_sessions addObject:session];
+    }
+
+    return session;
+}
+
+@end

--- a/SPDYUnitTests/SPDYProtocolTest.m
+++ b/SPDYUnitTests/SPDYProtocolTest.m
@@ -1,0 +1,217 @@
+//
+//  SPDYProtocolTest.m
+//  SPDY
+//
+//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import <Foundation/Foundation.h>
+#import "NSURLRequest+SPDYURLRequest.h"
+#import "SPDYProtocol.h"
+#import "SPDYTLSTrustEvaluator.h"
+
+@interface SPDYProtocolTest : SenTestCase<SPDYTLSTrustEvaluator>
+@end
+
+@implementation SPDYProtocolTest
+{
+    NSString *_lastTLSTrustHost;
+}
+
+- (void)tearDown
+{
+    _lastTLSTrustHost = nil;
+    [SPDYURLConnectionProtocol unregisterAllAliases];
+    [SPDYURLConnectionProtocol unregisterAllOrigins];
+    [SPDYProtocol setTLSTrustEvaluator:nil];
+}
+
+- (NSMutableURLRequest *)makeRequest:(NSString *)url
+{
+    return [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
+}
+
+#pragma mark SPDYTLSTrustEvaluator
+
+- (BOOL)evaluateServerTrust:(SecTrustRef)trust forHost:(NSString *)host
+{
+    _lastTLSTrustHost = host;
+    return NO;
+}
+
+#pragma mark Tests
+
+- (void)testURLSessionCanInitTrue
+{
+    STAssertTrue([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com"]], nil);
+    STAssertTrue([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+    STAssertTrue([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:443/foo"]], nil);
+    STAssertTrue([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:8888/foo"]], nil);
+    STAssertTrue([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"http://api.twitter.com/foo"]], nil);
+}
+
+- (void)testURLSessionCanInitFalse
+{
+    STAssertFalse([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"ftp://api.twitter.com"]], nil);
+    STAssertFalse([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"://api.twitter.com"]], nil);
+    STAssertFalse([SPDYURLSessionProtocol canInitWithRequest:[self makeRequest:@"api.twitter.com"]], nil);
+}
+
+- (void)testURLSessionWithBypassCanInitFalse
+{
+    NSMutableURLRequest *request = [self makeRequest:@"https://api.twitter.com"];
+    request.SPDYBypass = YES;
+    STAssertFalse([SPDYURLSessionProtocol canInitWithRequest:request], nil);
+}
+
+- (void)testURLConnectionCanInitTrue
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:443/foo"]], nil);
+}
+
+- (void)testURLConnectionCanInitFalse
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:8888/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"http://api.twitter.com"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://twitter.com"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://foo.api.twitter.com"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://twitter.com:80"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"http://api.twitter.com:443"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"://api.twitter.com"]], nil);
+}
+
+- (void)testURLConnectionWithBypassCanInitFalse
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    NSMutableURLRequest *request = [self makeRequest:@"https://api.twitter.com"];
+    request.SPDYBypass = YES;
+    STAssertFalse([SPDYURLSessionProtocol canInitWithRequest:request], nil);
+}
+
+- (void)testURLConnectionAliasCanInitTrue
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    [SPDYURLConnectionProtocol registerOrigin:@"https://1.2.3.4"];
+    [SPDYProtocol registerAlias:@"https://alias.twitter.com" forOrigin:@"https://api.twitter.com"];
+    [SPDYProtocol registerAlias:@"https://bare.twitter.com" forOrigin:@"https://1.2.3.4"];
+
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://1.2.3.4/foo"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://alias.twitter.com/foo"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://bare.twitter.com/foo"]], nil);
+
+    // TODO: Replace with unregisterAllAliases when available
+    [SPDYProtocol unregisterAlias:@"https://alias.twitter.com"];
+    [SPDYProtocol unregisterAlias:@"https://bare.twitter.com"];
+}
+
+- (void)testURLConnectionAliasToNoOriginCanInitFalse
+{
+    //[SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    [SPDYProtocol registerAlias:@"https://alias.twitter.com" forOrigin:@"https://api.twitter.com"];
+    [SPDYProtocol registerAlias:@"https://bare.twitter.com" forOrigin:@"https://1.2.3.4"];
+
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://1.2.3.4/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://alias.twitter.com/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://bare.twitter.com/foo"]], nil);
+
+    // TODO: Replace with unregisterAllAliases when available
+    [SPDYProtocol unregisterAlias:@"https://alias.twitter.com"];
+    [SPDYProtocol unregisterAlias:@"https://bare.twitter.com"];
+}
+
+- (void)testURLConnectionBadAliasCanInitFalse
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    [SPDYProtocol registerAlias:@"ftp://alias.twitter.com" forOrigin:@"https://api.twitter.com"]; // bad alias
+
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"ftp://alias.twitter.com/foo"]], nil);
+
+    // TODO: Replace with unregisterAllAliases when available
+    [SPDYProtocol unregisterAlias:@"ftp://alias.twitter.com"];
+}
+
+- (void)testURLConnectionCanInitTrueAfterWeirdOrigins
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com:8888"];
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:8888/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:8888/foo"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com:8889/foo"]], nil);
+
+    [SPDYURLConnectionProtocol registerOrigin:@"https://www.twitter.com/foo"];
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://www.twitter.com/foo"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://www.twitter.com"]], nil);
+}
+
+- (void)testURLConnectionCanInitFalseAfterBadOrigins
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"ftp://api.twitter.com"];
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com/foo"]], nil);
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"ftp://api.twitter.com/foo"]], nil);
+
+    [SPDYURLConnectionProtocol registerOrigin:@"https://"];
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://"]], nil);
+}
+
+- (void)testURLConnectionCanInitFalseAfterUnregister
+{
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    [SPDYURLConnectionProtocol registerOrigin:@"https://www.twitter.com"];
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://www.twitter.com"]], nil);
+
+    [SPDYURLConnectionProtocol unregisterOrigin:@"https://api.twitter.com"];
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://api.twitter.com"]], nil);
+    STAssertTrue([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://www.twitter.com"]], nil);
+
+    [SPDYURLConnectionProtocol unregisterAllOrigins];
+    STAssertFalse([SPDYURLConnectionProtocol canInitWithRequest:[self makeRequest:@"https://www.twitter.com"]], nil);
+}
+
+- (void)testTLSTrustEvaluatorReturnsYesWhenNotSet
+{
+    STAssertTrue([SPDYProtocol evaluateServerTrust:nil forHost:@"api.twitter.com"], nil);
+}
+
+- (void)testTLSTrustEvaluator
+{
+    [SPDYProtocol setTLSTrustEvaluator:self];
+    STAssertFalse([SPDYProtocol evaluateServerTrust:nil forHost:@"api.twitter.com"], nil);
+    STAssertEqualObjects(_lastTLSTrustHost, @"api.twitter.com", nil);
+}
+
+- (void)testTLSTrustEvaluatorWithCertificateAlias
+{
+    [SPDYProtocol setTLSTrustEvaluator:self];
+    [SPDYURLConnectionProtocol registerOrigin:@"https://api.twitter.com"];
+    [SPDYURLConnectionProtocol registerOrigin:@"https://1.2.3.4"];
+    [SPDYProtocol registerAlias:@"https://alias.twitter.com" forOrigin:@"https://api.twitter.com"];
+    [SPDYProtocol registerAlias:@"https://bare.twitter.com" forOrigin:@"https://1.2.3.4"];
+
+    STAssertFalse([SPDYProtocol evaluateServerTrust:nil forHost:@"api.twitter.com"], nil);
+    STAssertEqualObjects(_lastTLSTrustHost, @"api.twitter.com", nil);
+
+    STAssertFalse([SPDYProtocol evaluateServerTrust:nil forHost:@"1.2.3.4"], nil);
+    STAssertEqualObjects(_lastTLSTrustHost, @"bare.twitter.com", nil);
+
+    // TODO: Replace with unregisterAllAliases when available
+    [SPDYProtocol unregisterAlias:@"https://alias.twitter.com"];
+    [SPDYProtocol unregisterAlias:@"https://bare.twitter.com"];
+}
+
+@end
+

--- a/SPDYUnitTests/SPDYSessionManagerTest.m
+++ b/SPDYUnitTests/SPDYSessionManagerTest.m
@@ -6,17 +6,297 @@
 //  Licensed under the Apache License v2.0
 //  http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Created by Blake Watters on 5/29/14.
+//  Created by Kevin Goodier.
 //
 
 #import <SenTestingKit/SenTestingKit.h>
+#import <Foundation/Foundation.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+#import "NSURLRequest+SPDYURLRequest.h"
 #import "SPDYSession.h"
 #import "SPDYSessionManager.h"
+#import "SPDYSessionPool.h"
+#import "SPDYSocket+SPDYSocketMock.h"
+#import "SPDYStream.h"
+#import "SPDYProtocol.h"
+#import "SPDYOrigin.h"
+#import "SPDYStreamManager.h"
+#import "SPDYMockFrameDecoderDelegate.h"
+
+@interface SPDYSessionManager ()
+@property (nonatomic, readonly) SPDYStreamManager *pendingStreams;
+@property (nonatomic, readonly) SPDYSessionPool *basePool;
+@property (nonatomic, readonly) SPDYSessionPool *wwanPool;
+- (void)_updateReachability:(SCNetworkReachabilityFlags)flags;
+@end
+
+@implementation SPDYSessionManager (Test)
+
+- (SPDYStreamManager *)pendingStreams
+{
+    return [self valueForKey:@"_pendingStreams"];
+}
+
+- (SPDYSessionPool *)basePool
+{
+    return [self valueForKey:@"_basePool"];
+}
+
+- (SPDYSessionPool *)wwanPool
+{
+    return [self valueForKey:@"_wwanPool"];
+}
+
+@end
+
 
 @interface SPDYSessionManagerTest : SenTestCase
 
 @end
 
 @implementation SPDYSessionManagerTest
+{
+    SPDYMockFrameDecoderDelegate *_mockDecoderDelegate;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    [SPDYSocket performSwizzling:YES];
+    _mockDecoderDelegate = [[SPDYMockFrameDecoderDelegate alloc] init];
+    socketMock_frameDecoder = [[SPDYFrameDecoder alloc] initWithDelegate:_mockDecoderDelegate];
+
+    SPDYConfiguration *configuration = [SPDYConfiguration defaultConfiguration];
+    configuration.sessionPoolSize = 1;
+    configuration.enableTCPNoDelay = NO;
+    [SPDYProtocol setConfiguration:configuration];
+}
+
+- (void)tearDown
+{
+    socketMock_frameDecoder = nil;
+    [SPDYSocket performSwizzling:NO];
+    [super tearDown];
+}
+
+- (NSString *)nextOriginUrl
+{
+    static int sCount = 0;
+    return [NSString stringWithFormat:@"https://mocked%d.com", sCount++];
+}
+
+- (void)testDispatchQueuedStreamThenDoubleCanceledDoesReleaseStreamAndNotAssert
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYStream * __weak weakStream = nil;
+    @autoreleasepool {
+        SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+        weakStream = stream;
+        urlRequest.SPDYDeferrableInterval = 0;
+        stream.request = urlRequest;
+
+        // Assert initial state
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+        STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+        // Force base pool (non-cellular) reachability and then queue the stream
+        [sessionManager _updateReachability:kSCNetworkReachabilityFlagsReachable];
+        [sessionManager queueStream:stream];
+
+        // Assert stream is queued
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+        STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+        // Force callback to SPDYSessionManager's session:connectedToNetwork
+        SPDYSession *session = [[sessionManager basePool] nextSession];
+        [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+
+        // Assert stream has been dispatched
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+        STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+        // Assert a SYN_STREAM was written to the socket
+        STAssertTrue([_mockDecoderDelegate.lastFrame isKindOfClass:[SPDYSynStreamFrame class]], nil);
+
+        // Ensure a double cancel doesn't trigger an NSAssert
+        [stream cancel];
+        [stream cancel];
+
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+
+        [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    }
+
+    STAssertNil(weakStream, nil);
+}
+
+- (void)testDispatchQueuedStreamThenSessionClosesDoesReleaseStreamAndRemoveSession
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYStream * __weak weakStream = nil;
+    @autoreleasepool {
+        SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+        weakStream = stream;
+        urlRequest.SPDYDeferrableInterval = 0;
+        stream.request = urlRequest;
+
+        // Force base pool (non-cellular) reachability and then queue the stream
+        [sessionManager _updateReachability:kSCNetworkReachabilityFlagsReachable];
+        [sessionManager queueStream:stream];
+
+        // Force callback to SPDYSessionManager's session:connectedToNetwork
+        SPDYSession *session = [[sessionManager basePool] nextSession];
+        [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+
+        // Force socket to close session and remove streams
+        [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+
+        // Force socket to disconnect and remove session
+        [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+        STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+        STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+    }
+
+    STAssertNil(weakStream, nil);
+}
+
+- (void)testReachabilityChangesAfterQueueingStreamDoesDispatchNewStreamToNewSession
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    urlRequest.SPDYDeferrableInterval = 0;
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYProtocol *protocol2 = [[SPDYProtocol alloc] init];
+    SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+    stream.request = urlRequest;
+    SPDYStream *stream2 = [[SPDYStream alloc] initWithProtocol:protocol2];
+    stream2.request = urlRequest;
+
+    // Force reachability and queue stream1
+    [sessionManager _updateReachability:kSCNetworkReachabilityFlagsReachable];
+    [sessionManager queueStream:stream];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+    // Change reachability and queue stream2
+    [sessionManager _updateReachability:(kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN)];
+    [sessionManager queueStream:stream2];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)2, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+
+    // Force callback to SPDYSessionManager's wwan session:connectedToNetwork and dispatch stream
+    SPDYSession *session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+    session = [[sessionManager basePool] nextSession];
+    STAssertEquals(session.activeStreams.count, (NSUInteger)0, nil);
+    session = [[sessionManager wwanPool] nextSession];
+    STAssertEquals(session.activeStreams.count, (NSUInteger)2, nil);
+
+    // Force socket to close base session and remove streams
+    session = [[sessionManager basePool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+
+    session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+}
+
+- (void)testQueueStreamToWrongPoolAndReachabilityChangesBeforeConnectionFailsDoesDispatchToNewSession
+{
+    NSString *url = [self nextOriginUrl];
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:url error:nil];
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    urlRequest.SPDYDeferrableInterval = 0;
+    SPDYSessionManager *sessionManager = [SPDYSessionManager localManagerForOrigin:origin];
+
+    SPDYProtocol *protocol = [[SPDYProtocol alloc] init];
+    SPDYStream *stream = [[SPDYStream alloc] initWithProtocol:protocol];
+    stream.request = urlRequest;
+    SPDYProtocol *protocol2 = [[SPDYProtocol alloc] init];
+    SPDYStream *stream2 = [[SPDYStream alloc] initWithProtocol:protocol2];
+    stream2.request = urlRequest;
+
+    // Force reachability and queue stream1
+    [sessionManager _updateReachability:kSCNetworkReachabilityFlagsReachable];
+    [sessionManager queueStream:stream];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+    // Put stream1 into wrong pool artificially
+    SPDYSession *session = [[sessionManager basePool] nextSession];
+    [session setCellular:true];
+
+    // Force session connection error
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+    STAssertFalse(session.isOpen, nil);
+
+    // We put the stream in the basePool but it thinks it is wwan. That case *should* be handled
+    // by the session manager.
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)1, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+
+    // Change reachability. This will dispatch. We'll also force a dispatch.
+    [sessionManager _updateReachability:(kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN)];
+    [sessionManager queueStream:stream2];
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)2, nil);
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)1, nil);
+
+    session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil didConnectToHost:@"mocked.com" port:55555];
+    STAssertTrue(session.isOpen, nil);
+
+    STAssertEquals([sessionManager.pendingStreams count], (NSUInteger)0, nil);
+    session = [[sessionManager wwanPool] nextSession];
+    STAssertEquals(session.activeStreams.count, (NSUInteger)2, nil);
+
+    // Force socket to close wwan session and remove streams
+    session = [[sessionManager wwanPool] nextSession];
+    [(id <SPDYSocketDelegate>)session socket:nil willDisconnectWithError:nil];
+    [(id <SPDYSocketDelegate>)session socketDidDisconnect:nil];
+
+    STAssertEquals([[sessionManager basePool] count], (NSUInteger)0, nil);
+    STAssertEquals([[sessionManager wwanPool] count], (NSUInteger)0, nil);
+}
 
 @end

--- a/SPDYUnitTests/SPDYSettingsStoreTest.m
+++ b/SPDYUnitTests/SPDYSettingsStoreTest.m
@@ -1,0 +1,113 @@
+//
+//  SPDYSettingsStoreTest.m
+//  SPDY
+//
+//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import <Foundation/Foundation.h>
+#import "SPDYSettingsStore.h"
+#import "SPDYOrigin.h"
+#import "SPDYDefinitions.h"
+
+@interface SPDYSettingsStoreTest : SenTestCase
+@end
+
+@implementation SPDYSettingsStoreTest
+
+- (void)testSettings:(SPDYSettings *)settings
+{
+    SPDY_SETTINGS_ITERATOR(i) {
+        settings[i].set = NO;
+    }
+
+    settings[SPDY_SETTINGS_DOWNLOAD_BANDWIDTH].set = YES;
+    settings[SPDY_SETTINGS_DOWNLOAD_BANDWIDTH].value = 1;
+    settings[SPDY_SETTINGS_DOWNLOAD_BANDWIDTH].flags = SPDY_SETTINGS_FLAG_PERSIST_VALUE;
+
+    settings[SPDY_SETTINGS_CLIENT_CERTIFICATE_VECTOR_SIZE].set = YES;
+    settings[SPDY_SETTINGS_CLIENT_CERTIFICATE_VECTOR_SIZE].value = 2;
+    settings[SPDY_SETTINGS_CLIENT_CERTIFICATE_VECTOR_SIZE].flags = SPDY_SETTINGS_FLAG_PERSIST_VALUE;
+
+    settings[SPDY_SETTINGS_MAX_CONCURRENT_STREAMS].set = YES;
+    settings[SPDY_SETTINGS_MAX_CONCURRENT_STREAMS].value = 3;
+    settings[SPDY_SETTINGS_MAX_CONCURRENT_STREAMS].flags = 0;  // not persisted
+}
+
+#pragma mark Tests
+
+- (void)testSettingsForWrongOrigin
+{
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:@"https://api.twitter.com" error:nil];
+    SPDYOrigin *origin2 = [[SPDYOrigin alloc] initWithString:@"http://api.twitter.com" error:nil];
+
+    SPDYSettings settings[SPDY_SETTINGS_LENGTH];
+    [self testSettings:settings];
+
+    [SPDYSettingsStore persistSettings:settings forOrigin:origin];
+
+    SPDYSettings *persistedSettings;
+    persistedSettings = [SPDYSettingsStore settingsForOrigin:origin2];  // invalid origin
+    STAssertTrue(persistedSettings == NULL, nil);
+}
+
+- (void)testSettingsForOrigin
+{
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:@"https://api.twitter.com" error:nil];
+
+    SPDYSettings settings[SPDY_SETTINGS_LENGTH];
+    [self testSettings:settings];
+
+    [SPDYSettingsStore persistSettings:settings forOrigin:origin];
+
+    SPDYSettings *persistedSettings;
+    persistedSettings = [SPDYSettingsStore settingsForOrigin:origin];
+    STAssertTrue(persistedSettings != NULL, nil);
+
+    STAssertTrue(persistedSettings[SPDY_SETTINGS_DOWNLOAD_BANDWIDTH].set, nil);
+    STAssertTrue(persistedSettings[SPDY_SETTINGS_CLIENT_CERTIFICATE_VECTOR_SIZE].set, nil);
+    STAssertFalse(persistedSettings[SPDY_SETTINGS_MAX_CONCURRENT_STREAMS].set, nil);
+    STAssertFalse(persistedSettings[SPDY_SETTINGS_ROUND_TRIP_TIME].set, nil);
+
+    STAssertEquals(persistedSettings[SPDY_SETTINGS_DOWNLOAD_BANDWIDTH].value, 1, nil);
+    STAssertEquals(persistedSettings[SPDY_SETTINGS_CLIENT_CERTIFICATE_VECTOR_SIZE].value, 2, nil);
+}
+
+- (void)testClearSettings
+{
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:@"https://api.twitter.com" error:nil];
+
+    SPDYSettings settings[SPDY_SETTINGS_LENGTH];
+    [self testSettings:settings];
+
+    [SPDYSettingsStore persistSettings:settings forOrigin:origin];
+    [SPDYSettingsStore clearSettingsForOrigin:origin];
+
+    SPDYSettings *persistedSettings;
+    persistedSettings = [SPDYSettingsStore settingsForOrigin:origin];
+    STAssertTrue(persistedSettings != NULL, nil);
+
+    STAssertFalse(persistedSettings[SPDY_SETTINGS_DOWNLOAD_BANDWIDTH].set, nil);
+    STAssertFalse(persistedSettings[SPDY_SETTINGS_CLIENT_CERTIFICATE_VECTOR_SIZE].set, nil);
+    STAssertFalse(persistedSettings[SPDY_SETTINGS_MAX_CONCURRENT_STREAMS].set, nil);
+    STAssertFalse(persistedSettings[SPDY_SETTINGS_ROUND_TRIP_TIME].set, nil);
+}
+
+- (void)testClearSettingsWhenNonePersisted
+{
+    SPDYOrigin *origin = [[SPDYOrigin alloc] initWithString:@"https://api2.twitter.com" error:nil];
+
+    [SPDYSettingsStore clearSettingsForOrigin:origin];
+
+    SPDYSettings *persistedSettings;
+    persistedSettings = [SPDYSettingsStore settingsForOrigin:origin];
+    STAssertTrue(persistedSettings == NULL, nil);
+}
+
+@end
+

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.h
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.h
@@ -13,6 +13,7 @@
 #import "SPDYSession.h"
 
 @class SPDYFrameDecoder;
+@class SPDYStreamManager;
 
 // TODO: remove this once the proxy fork has been merged and the socket op structures are in
 // their own header file that can be imported here.
@@ -65,4 +66,6 @@ extern SPDYFrameDecoder *socketMock_frameDecoder;
 @property (nonatomic, readonly) SPDYSocket *socket;
 @property (nonatomic, readonly) NSMutableData *inputBuffer;
 @property (nonatomic, readonly) SPDYFrameDecoder *frameDecoder;
+@property (nonatomic, readonly) SPDYStreamManager *activeStreams;
+- (void)setCellular:(bool)cellular;
 @end

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
@@ -11,6 +11,7 @@
 
 #import "SPDYSocket+SPDYSocketMock.h"
 #import "SPDYFrameDecoder.h"
+#import "SPDYStreamManager.h"
 #import <objc/runtime.h>
 
 NSString * const kSPDYTSTResponseStubs = @"kSPDYTSTResponseStubs";
@@ -34,6 +35,16 @@ SPDYFrameDecoder *socketMock_frameDecoder = nil;
 - (SPDYFrameDecoder *)frameDecoder
 {
     return [self valueForKey:@"_frameDecoder"];
+}
+
+- (SPDYStreamManager *)activeStreams
+{
+    return [self valueForKey:@"_activeStreams"];
+}
+
+- (void)setCellular:(bool)cellular
+{
+    [self setValue:@(cellular) forKey:@"_cellular"];
 }
 
 @end


### PR DESCRIPTION
Lots of filling of gaps and some refactoring. Lots more to do.

- Add coverage & build badges to both master & develop branches.
- Remove unit tests from code coverage. Slipped in at some point.
- Based on code coverage, eliminate dead code in NSURLRequest.
- First unit tests for session manager for streams & sessions.
- Backfill a previous race condition bug around queuing stream to one pool but it
  opening in another.