### PR TITLE
Explicitly list destination in Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 before_install:
   - brew update
   - sudo easy_install cpp-coveralls
-script: "xcodebuild test -workspace SPDY.xcodeproj/project.xcworkspace/ -scheme SPDYUnitTests -sdk iphonesimulator"
+script: "xcodebuild test -workspace SPDY.xcodeproj/project.xcworkspace/ -scheme SPDYUnitTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.1'"
 after_success: 
   - cp -r ${HOME}/Library/Developer/Xcode/DerivedData/SPDY-*/Build/Intermediates/SPDY.build/Coverage-iphonesimulator/SPDYUnitTests.build/Objects-normal/*/ gcov
   - rm -f gcov/*Test.*


### PR DESCRIPTION
Travis is acting odd -- I tried specifying an iOS 7.1 build for an iPhone 5s but xcodebuild complained about being unable to find that destination, despite subsequently listing that exact destination as one that is available. So for now, I'm not going the extra mile and instead just defaulting to an iPhone 6 iOS 8.1 build for the unit tests. We'll have to still manually verify iOS 7.1.