### PR TITLE
Add "isCellular" to metadata.

### DIFF
--- a/SPDY/SPDYMetadata.m
+++ b/SPDY/SPDYMetadata.m
@@ -53,6 +53,7 @@ static NSString * const SPDYMetadataIdentifierKey = @"x-spdy-metadata-identifier
         SPDYMetadataStreamBlockedMsKey : [@(_blockedMs) stringValue],
         SPDYMetadataSessionViaProxyKey : [@(_viaProxy) stringValue],
         SPDYMetadataSessionProxyStatusKey : [@(_proxyStatus) stringValue],
+        SPDYMetadataSessionIsCellularKey : [@(_cellular) stringValue],
     }];
 
     if (_streamId > 0) {

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -24,6 +24,9 @@ extern NSString *const SPDYOriginUnregisteredNotification;
 // SPDY version, e.g. "3.1"
 extern NSString *const SPDYMetadataVersionKey;
 
+// Boolean indicating whether session is over cellular or WIFI
+extern NSString *const SPDYMetadataSessionIsCellularKey;
+
 // IP address of remote side
 extern NSString *const SPDYMetadataSessionRemoteAddressKey;
 

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -32,6 +32,7 @@ NSString *const SPDYSocketErrorDomain = @"SPDYSocketErrorDomain";
 NSString *const SPDYOriginRegisteredNotification = @"SPDYOriginRegisteredNotification";
 NSString *const SPDYOriginUnregisteredNotification = @"SPDYOriginUnregisteredNotification";
 NSString *const SPDYMetadataVersionKey = @"x-spdy-version";
+NSString *const SPDYMetadataSessionIsCellularKey = @"x-spdy-session-is-cellular";
 NSString *const SPDYMetadataSessionRemoteAddressKey = @"x-spdy-session-remote-address";
 NSString *const SPDYMetadataSessionRemotePortKey = @"x-spdy-session-remote-port";
 NSString *const SPDYMetadataSessionViaProxyKey = @"x-spdy-session-via-proxy";

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -114,7 +114,6 @@
             _origin = origin;
             SPDY_INFO(@"session connecting to %@", _origin);
 
-            // TODO: for accuracy confirm this later from the socket
             _cellular = cellular;
 
             if ([_origin.scheme isEqualToString:@"https"]) {
@@ -195,6 +194,7 @@
     stream.metadata.hostAddress = _socket.connectedHost;
     stream.metadata.hostPort = _socket.connectedPort;
     stream.metadata.viaProxy = _socket.connectedToProxy;
+    stream.metadata.cellular = _cellular;
 
     [stream startWithStreamId:streamId
                sendWindowSize:_initialSendWindowSize
@@ -290,6 +290,19 @@
 {
     [_connectedStopwatch reset];
     SPDY_INFO(@"session connected to %@ (%@:%u)", _origin, host, port);
+
+    if (_cellular != socket.isCellular) {
+        SPDY_WARNING(@"session expected network type %@ but socket is %@",
+                _cellular ? @"cellular" : @"wifi",
+                socket.isCellular ? @"cellular" : @"wifi");
+
+        _cellular = socket.isCellular;
+
+        // Update metadata
+        for (SPDYStream *stream in _activeStreams) {
+            stream.metadata.cellular = _cellular;
+        }
+    }
 
     _connected = YES;
     [_delegate session:self connectedToNetwork:_cellular];

--- a/SPDY/SPDYSessionManager.h
+++ b/SPDY/SPDYSessionManager.h
@@ -13,7 +13,7 @@
 
 @protocol SPDYSessionDelegate;
 
-@interface SPDYSessionManager : NSObject <SPDYSessionDelegate>
+@interface SPDYSessionManager : NSObject
 
 + (SPDYSessionManager *)localManagerForOrigin:(SPDYOrigin *)origin;
 - (void)queueStream:(SPDYStream *)stream;

--- a/SPDY/SPDYSessionPool.h
+++ b/SPDY/SPDYSessionPool.h
@@ -19,7 +19,6 @@
 @property (nonatomic, assign, readonly) NSUInteger count;
 @property (nonatomic, assign) NSUInteger pendingCount;
 
-- (id)initWithOrigin:(SPDYOrigin *)origin manager:(SPDYSessionManager *)manager cellular:(bool)cellular error:(NSError **)pError;
 - (bool)contains:(SPDYSession *)session;
 - (void)add:(SPDYSession *)session;
 - (NSUInteger)count;

--- a/SPDY/SPDYSessionPool.m
+++ b/SPDY/SPDYSessionPool.m
@@ -13,36 +13,19 @@
 #error "This file requires ARC support."
 #endif
 
-#import "SPDYProtocol.h"
 #import "SPDYSession.h"
-#import "SPDYSessionManager.h"
 #import "SPDYSessionPool.h"
-#import "SPDYStream.h"
 
 @implementation SPDYSessionPool
 {
     NSMutableArray *_sessions;
 }
 
-- (id)initWithOrigin:(SPDYOrigin *)origin manager:(SPDYSessionManager *)manager cellular:(bool)cellular error:(NSError **)pError
+- (id)init
 {
     self = [super init];
     if (self) {
-        SPDYConfiguration *configuration = [SPDYProtocol currentConfiguration];
-        NSUInteger size = configuration.sessionPoolSize;
-        _pendingCount = size;
-        _sessions = [[NSMutableArray alloc] initWithCapacity:size];
-        for (NSUInteger i = 0; i < size; i++) {
-            SPDYSession *session = [[SPDYSession alloc] initWithOrigin:origin
-                                                              delegate:manager
-                                                         configuration:configuration
-                                                              cellular:cellular
-                                                                 error:pError];
-            if (!session) {
-                return nil;
-            }
-            [_sessions addObject:session];
-        }
+        _sessions = [[NSMutableArray alloc] init];
     }
     return self;
 }

--- a/SPDY/SPDYSocket.h
+++ b/SPDY/SPDYSocket.h
@@ -145,6 +145,7 @@ extern NSString *const SPDYSocketException;
 
 @interface SPDYSocket : NSObject
 @property (nonatomic, strong) id<SPDYSocketDelegate> delegate;
+@property (nonatomic, readonly) bool isCellular;
 
 - (id)initWithDelegate:(id<SPDYSocketDelegate>)delegate;
 - (CFSocketRef)cfSocket;

--- a/SPDY/SPDYSocket.m
+++ b/SPDY/SPDYSocket.m
@@ -885,6 +885,12 @@ static void SPDYSocketCFWriteStreamCallback(CFWriteStreamRef stream, CFStreamEve
 
     CFRelease(peeraddr);
 
+    CFBooleanRef cellularProp = CFReadStreamCopyProperty(_readStream, kCFStreamPropertyConnectionIsCellular);
+    if (cellularProp != NULL) {
+        _isCellular = CFBooleanGetValue(cellularProp);
+        CFRelease(cellularProp);
+    }
+
     return YES;
 }
 

--- a/SPDYUnitTests/SPDYMetadataTest.m
+++ b/SPDYUnitTests/SPDYMetadataTest.m
@@ -64,6 +64,7 @@
     STAssertNil(dict[SPDYMetadataSessionRemotePortKey], nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionViaProxyKey], @"0", nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionProxyStatusKey], @"0", nil);
+    STAssertEqualObjects(dict[SPDYMetadataSessionIsCellularKey], @"0", nil);
 }
 
 - (void)testSerializeToDictionary
@@ -82,6 +83,7 @@
     STAssertEqualObjects(dict[SPDYMetadataSessionRemotePortKey], @"1", nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionViaProxyKey], @"1", nil);
     STAssertEqualObjects(dict[SPDYMetadataSessionProxyStatusKey], @"1", nil);
+    STAssertEqualObjects(dict[SPDYMetadataSessionIsCellularKey], @"1", nil);
 }
 
 - (void)testMemberRetention

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.h
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.h
@@ -43,6 +43,7 @@ extern SPDYFrameDecoder *socketMock_frameDecoder;
 //@property (nonatomic) NSArray *responseStubs;
 
 + (void)performSwizzling:(BOOL)performSwizzling;
+- (void)setCellular:(bool)cellular;
 
 #pragma mark - SPDYSocketDelegate call forwarding
 - (void)performDelegateCall_socketWillDisconnectWithError:(NSError *)error;

--- a/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
+++ b/SPDYUnitTests/SPDYSocket+SPDYSocketMock.m
@@ -83,12 +83,17 @@ SPDYFrameDecoder *socketMock_frameDecoder = nil;
     }
 }
 
+- (void)setCellular:(bool)cellular
+{
+    [self setValue:@(cellular) forKey:@"_isCellular"];
+}
+
 - (bool)swizzled_connectToOrigin:(SPDYOrigin *)origin
                      withTimeout:(NSTimeInterval)timeout
                            error:(NSError **)pError
 {
     NSLog(@"SPDYMock: Swizzled connectToOrigin:%@ withTimeout:%f error", origin, timeout);
-
+    [self setValue:@(1) forKey:@"_flags"];  // kDidStartDelegate
     return YES;
 }
 


### PR DESCRIPTION
This also fixes SPDYSession to pay attention to what the socket actually
does, rather than just assume the socket did the right thing. When there
is a discrepancy, SPDYSessionManager will move the session into the
correct pool.