### PR TITLE
Add richer NSURLSession support.

### DIFF
--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -130,6 +130,9 @@
 		7774CD9416661E40D76713F5 /* SPDYStopwatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 7774CE030BB898D2BE3D320D /* SPDYStopwatch.h */; };
 		7774CDD84A5D07F8DE5B8684 /* SPDYStopwatch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7774CE34A3AA067D98DA7ECC /* SPDYStopwatch.m */; };
 		7774CF887055793F373F0D5E /* SPDYStopwatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 7774CE030BB898D2BE3D320D /* SPDYStopwatch.h */; };
+		8B40E8AA1AE1B95C000A0F0F /* SPDYProtocol+Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B40E8A81AE1B95C000A0F0F /* SPDYProtocol+Project.h */; };
+		8B40E8AB1AE1B95C000A0F0F /* SPDYProtocol+Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B40E8A81AE1B95C000A0F0F /* SPDYProtocol+Project.h */; };
+		8B40E8AC1AE1B95C000A0F0F /* SPDYProtocol+Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B40E8A81AE1B95C000A0F0F /* SPDYProtocol+Project.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -211,6 +214,7 @@
 		7774CD0A3295C8E314D6E3FF /* SPDYMockFrameEncoderDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYMockFrameEncoderDelegate.h; sourceTree = "<group>"; };
 		7774CE030BB898D2BE3D320D /* SPDYStopwatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYStopwatch.h; sourceTree = "<group>"; };
 		7774CE34A3AA067D98DA7ECC /* SPDYStopwatch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYStopwatch.m; sourceTree = "<group>"; };
+		8B40E8A81AE1B95C000A0F0F /* SPDYProtocol+Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPDYProtocol+Project.h"; sourceTree = "<group>"; };
 		D2CC14B216179B43002E37CF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D2CC14B816179B43002E37CF /* SPDY-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPDY-Prefix.pch"; sourceTree = "<group>"; };
 		D2CC14C01618CF62002E37CF /* SPDYProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYProtocol.h; sourceTree = "<group>"; };
@@ -374,11 +378,11 @@
 		D2CC14B416179B43002E37CF /* SPDY */ = {
 			isa = PBXGroup;
 			children = (
-				5C6B0D271A3A3E8400334BFA /* SPDYCanonicalRequest.h */,
-				5C6B0D281A3A3E8400334BFA /* SPDYCanonicalRequest.m */,
 				069D0E99168268F10037D8AF /* NSURLRequest+SPDYURLRequest.h */,
 				069D0E9A168268F10037D8AF /* NSURLRequest+SPDYURLRequest.m */,
 				D2CC14B816179B43002E37CF /* SPDY-Prefix.pch */,
+				5C6B0D271A3A3E8400334BFA /* SPDYCanonicalRequest.h */,
+				5C6B0D281A3A3E8400334BFA /* SPDYCanonicalRequest.m */,
 				062EA63E175D4CD3003BC1CE /* SPDYCommonLogger.h */,
 				062EA63F175D4CD3003BC1CE /* SPDYCommonLogger.m */,
 				062EA63C175D1A15003BC1CE /* SPDYDefinitions.h */,
@@ -404,6 +408,7 @@
 				5C9A0BCF1A363BDC00CF2D3D /* SPDYOriginEndpointManager.m */,
 				D2CC14C01618CF62002E37CF /* SPDYProtocol.h */,
 				D2CC14C11618CF62002E37CF /* SPDYProtocol.m */,
+				8B40E8A81AE1B95C000A0F0F /* SPDYProtocol+Project.h */,
 				D2CC14C31618DBF2002E37CF /* SPDYSession.h */,
 				D2CC14C41618DBF2002E37CF /* SPDYSession.m */,
 				D2CC14CC161A5826002E37CF /* SPDYSessionManager.h */,
@@ -437,6 +442,7 @@
 			files = (
 				0540DAAB19CB7FF000673796 /* NSURLRequest+SPDYURLRequest.h in Headers */,
 				0540DAAC19CB7FF900673796 /* SPDYError.h in Headers */,
+				8B40E8AB1AE1B95C000A0F0F /* SPDYProtocol+Project.h in Headers */,
 				0540DAAD19CB800C00673796 /* SPDYLogger.h in Headers */,
 				0540DAAE19CB801900673796 /* SPDYProtocol.h in Headers */,
 				0540DAAF19CB802600673796 /* SPDYTLSTrustEvaluator.h in Headers */,
@@ -452,6 +458,7 @@
 			files = (
 				05C7CEB919CB456D0032D681 /* NSURLRequest+SPDYURLRequest.h in Headers */,
 				0540DAA719CB7FD600673796 /* SPDYError.h in Headers */,
+				8B40E8AA1AE1B95C000A0F0F /* SPDYProtocol+Project.h in Headers */,
 				05C7CEBA19CB45760032D681 /* SPDYLogger.h in Headers */,
 				05C7CEBB19CB45820032D681 /* SPDYProtocol.h in Headers */,
 				05C7CEBC19CB458F0032D681 /* SPDYTLSTrustEvaluator.h in Headers */,
@@ -467,6 +474,7 @@
 			files = (
 				064A05D616F8E3AD008C7D08 /* NSURLRequest+SPDYURLRequest.h in Headers */,
 				06811C971714D426000D1677 /* SPDYError.h in Headers */,
+				8B40E8AC1AE1B95C000A0F0F /* SPDYProtocol+Project.h in Headers */,
 				06811C9B1715DC85000D1677 /* SPDYLogger.h in Headers */,
 				064A05C716F7C313008C7D08 /* SPDYProtocol.h in Headers */,
 				06E7BF131824371F004DB65D /* SPDYTLSTrustEvaluator.h in Headers */,

--- a/SPDY/NSURLRequest+SPDYURLRequest.h
+++ b/SPDY/NSURLRequest+SPDYURLRequest.h
@@ -53,9 +53,18 @@
 @property (nonatomic, readonly) BOOL SPDYBypass;
 
 /**
+  Contextual NSURLSession that was associated with this request. The application
+  should set this if using NSURLSession to load the request in order to provide
+  proper per-request configuration information, and if support for the
+  extended SPDYURLSessionDelegate is desired.
+ */
+@property (nonatomic, readonly) NSURLSession *SPDYURLSession;
+
+/**
   Request header fields canonicalized to SPDY format.
 */
 - (NSDictionary *)allSPDYHeaderFields;
+
 @end
 
 @interface NSMutableURLRequest (SPDYURLRequest)
@@ -64,4 +73,5 @@
 @property (nonatomic) NSTimeInterval SPDYDeferrableInterval;
 @property (nonatomic) NSUInteger SPDYPriority;
 @property (nonatomic) BOOL SPDYBypass;
+@property (nonatomic) NSURLSession *SPDYURLSession;
 @end

--- a/SPDY/SPDYProtocol+Project.h
+++ b/SPDY/SPDYProtocol+Project.h
@@ -11,6 +11,6 @@
 @interface SPDYProtocol (Project)
 
 @property (nonatomic, readonly) NSURLSession *associatedSession;
-@property (nonatomic, readonly) NSURLSessionTask *associatedSessionTask;
+@property (nonatomic, readonly, weak) NSURLSessionTask *associatedSessionTask;
 
 @end

--- a/SPDY/SPDYProtocol+Project.h
+++ b/SPDY/SPDYProtocol+Project.h
@@ -1,0 +1,16 @@
+//
+//  SPDYProtocol+Project.h
+//  SPDY
+//
+//  Created by Nolan O'Brien on 4/17/15.
+//  Copyright (c) 2015 Twitter. All rights reserved.
+//
+
+#import <SPDY/SPDYProtocol.h>
+
+@interface SPDYProtocol (Project)
+
+@property (nonatomic, readonly) NSURLSession *associatedSession;
+@property (nonatomic, readonly) NSURLSessionTask *associatedSessionTask;
+
+@end

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -145,6 +145,11 @@ extern NSString *const SPDYMetadataStreamTxBytesKey;
 */
 + (void)unregisterAllAliases;
 
+/**
+  Get the SPDY metadata from a protocol instance.
+ */
+- (NSDictionary *)metadata;
+
 @end
 
 /**
@@ -286,5 +291,24 @@ extern NSString *const SPDYMetadataStreamTxBytesKey;
   the system-configured proxy information and forces use of a proxy.
 */
 @property NSInteger proxyPort;
+
+@end
+
+/**
+  Protocol that may be implemented by the delegate property of NSURLSession.
+ 
+  This will provide additional context for the request, if desired. Implementing
+  it is optional, and only applies for NSURLSession-based requests. All calls 
+  made using the NSOperationQueue set in delegateQueue in NSURLSession, or else 
+  the mainQueue if one is not set.
+*/
+@protocol SPDYURLSessionDelegate <NSObject>
+
+/**
+  Called just before the request is dispatched and provides the SPDYProtocol 
+  instance handling the request.
+*/
+@optional
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didStartLoadingRequest:(NSURLRequest *)request withSPDYProtocol:(SPDYProtocol *)protocol;
 
 @end

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -145,11 +145,6 @@ extern NSString *const SPDYMetadataStreamTxBytesKey;
 */
 + (void)unregisterAllAliases;
 
-/**
-  Get the SPDY metadata from a protocol instance.
- */
-- (NSDictionary *)metadata;
-
 @end
 
 /**
@@ -295,6 +290,24 @@ extern NSString *const SPDYMetadataStreamTxBytesKey;
 @end
 
 /**
+  SPDYProtocolContext is provided by the SPDYURLSessionDelegate protocol when
+  the request starts loading. It can be used by the app to retrieve additional
+  information about the request instance.
+*/
+
+@protocol SPDYProtocolContext <NSObject>
+
+/**
+  Get the SPDY metadata from a protocol instance. This should only be called 
+  once a request has either completed or returned an error. Use at any other
+  time has undefined behavior. The use of this, metadataForResponse, and 
+  metadataForError are all interchangeable.
+ */
+- (NSDictionary *)metadata;
+
+@end
+
+/**
   Protocol that may be implemented by the delegate property of NSURLSession.
  
   This will provide additional context for the request, if desired. Implementing
@@ -309,6 +322,6 @@ extern NSString *const SPDYMetadataStreamTxBytesKey;
   instance handling the request.
 */
 @optional
-- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didStartLoadingRequest:(NSURLRequest *)request withSPDYProtocol:(SPDYProtocol *)protocol;
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didStartLoadingRequest:(NSURLRequest *)request withContext:(id<SPDYProtocolContext>)context;
 
 @end

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -14,12 +14,13 @@
 #endif
 
 #import <arpa/inet.h>
+#import <Foundation/Foundation.h>
 #import "NSURLRequest+SPDYURLRequest.h"
 #import "SPDYCanonicalRequest.h"
 #import "SPDYCommonLogger.h"
 #import "SPDYMetadata.h"
 #import "SPDYOrigin.h"
-#import "SPDYProtocol.h"
+#import "SPDYProtocol+Project.h"
 #import "SPDYSession.h"
 #import "SPDYSessionManager.h"
 #import "SPDYStream.h"
@@ -50,6 +51,10 @@ static NSMutableDictionary *aliases;
 static NSMutableDictionary *certificates;
 static dispatch_queue_t configQueue;
 static dispatch_once_t initConfig;
+
+@interface NSURLRequest (SPDYURLRequest_Internal)
+- (NSString *)SPDYURLSessionRequestIdentifier;
+@end
 
 @interface SPDYAssertionHandler : NSAssertionHandler
 @property (nonatomic) BOOL abortOnFailure;
@@ -108,6 +113,12 @@ static dispatch_once_t initConfig;
 @implementation SPDYProtocol
 {
     SPDYStream *_stream;
+    NSURLSession *_associatedSession;
+    NSURLSessionTask *_associatedSessionTask;
+    struct {
+        BOOL didStartLoading:1;
+        BOOL didStopLoading:1;
+    } _flags;
 }
 
 static SPDYConfiguration *currentConfiguration;
@@ -309,6 +320,16 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
 
 - (void)startLoading
 {
+    // Only allow one startLoading call. iOS 8 using NSURLSession has exhibited different
+    // behavior, by calling startLoading, then stopLoading, then startLoading, etc, over and
+    // over. This happens asynchronously when using a NSURLSessionDataTaskDelegate after the
+    // URLSession:dataTask:didReceiveResponse:completionHandler: callback.
+    if (_flags.didStartLoading) {
+        SPDY_WARNING(@"start loading already called, ignoring %@", self.request.URL.absoluteString);
+        return;
+    }
+    _flags.didStartLoading = 1;
+
     // Add an assertion handler to this NSURL thread if one doesn't exist. Without it, assertions
     // will get swallowed on iOS. OSX seems to behave properly without it, but it's safer to
     // just always set this.
@@ -317,18 +338,10 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
         currentThreadDictionary[NSAssertionHandlerKey] = [[SPDYAssertionHandler alloc] init];
     }
 
-    // Only allow one startLoading call. iOS 8 using NSURLSession has exhibited different
-    // behavior, by calling startLoading, then stopLoading, then startLoading, etc, over and
-    // over. This happens asynchronously when using a NSURLSessionDataTaskDelegate after the
-    // URLSession:dataTask:didReceiveResponse:completionHandler: callback.
-    if (_stream) {
-        SPDY_WARNING(@"start loading already called, ignoring %@", self.request.URL.absoluteString);
-        return;
-    }
-
     NSURLRequest *request = self.request;
     SPDY_INFO(@"start loading %@", request.URL.absoluteString);
 
+    // Check the origin
     NSError *error;
     SPDYOrigin *origin = [[SPDYOrigin alloc] initWithURL:request.URL error:&error];
     if (!origin) {
@@ -336,14 +349,74 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
         return;
     }
 
+    // Check for an alias
     SPDYOrigin *aliasedOrigin = [SPDYProtocol originForAlias:origin];
     if (aliasedOrigin) {
         origin = aliasedOrigin;
     }
 
-    SPDYSessionManager *manager = [SPDYSessionManager localManagerForOrigin:origin];
+    // Create the stream
     _stream = [[SPDYStream alloc] initWithProtocol:self];
-    [manager queueStream:_stream];
+
+    if (request.SPDYURLSession) {
+        [self detectSessionAndTaskThenContinueWithOrigin:origin];
+    } else {
+        // Start the stream
+        SPDYSessionManager *manager = [SPDYSessionManager localManagerForOrigin:origin];
+        [manager queueStream:_stream];
+    }
+}
+
+- (void)detectSessionAndTaskThenContinueWithOrigin:(SPDYOrigin *)origin
+{
+    NSURLRequest *request = self.request;
+    NSURLSession *session = request.SPDYURLSession;
+    NSString *sessionRequestIdentifier = request.SPDYURLSessionRequestIdentifier;
+
+    NSAssert(session != nil, @"%@ should never be called without an associated %@", NSStringFromSelector(_cmd), NSStringFromSelector(@selector(SPDYURLSession)));
+
+    CFRunLoopRef clientRunLoop = CFRunLoopGetCurrent();
+    CFRetain(clientRunLoop);
+
+    [session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
+        NSURLSessionTask *matchingTask = nil;
+        NSMutableArray *tasks = [NSMutableArray array];
+        [tasks addObjectsFromArray:dataTasks];
+        [tasks addObjectsFromArray:uploadTasks];
+        [tasks addObjectsFromArray:downloadTasks];
+
+        for (NSURLSessionTask *task in tasks) {
+            if ([task.currentRequest.SPDYURLSessionRequestIdentifier isEqualToString:sessionRequestIdentifier]) {
+                matchingTask = task;
+                break;
+            }
+        }
+
+        dispatch_block_t continueBlock = ^{
+            if (!_flags.didStopLoading) {
+                if (matchingTask) {
+                    _associatedSessionTask = matchingTask;
+                    _associatedSession = session;
+
+                    id<SPDYURLSessionDelegate> delegate = (id)session.delegate;
+                    if ([delegate respondsToSelector:@selector(URLSession:task:didStartLoadingRequest:withSPDYProtocol:)]) {
+                        NSOperationQueue *queue = session.delegateQueue;
+                        [(queue) ?: [NSOperationQueue mainQueue] addOperationWithBlock:^{
+                            [delegate URLSession:session task:matchingTask didStartLoadingRequest:request withSPDYProtocol:self];
+                        }];
+                    }
+                }
+
+                // Start the stream
+                SPDYSessionManager *manager = [SPDYSessionManager localManagerForOrigin:origin];
+                [manager queueStream:_stream];
+            }
+        };
+
+        CFRunLoopPerformBlock(clientRunLoop, kCFRunLoopDefaultMode, continueBlock);
+        CFRunLoopWakeUp(clientRunLoop);
+        CFRelease(clientRunLoop);
+    }];
 }
 
 - (void)stopLoading
@@ -353,6 +426,26 @@ static id<SPDYTLSTrustEvaluator> trustEvaluator;
     if (_stream && !_stream.closed) {
         [_stream cancel];
     }
+    _flags.didStopLoading = 1;
+    _associatedSession = nil;
+    _associatedSessionTask = nil;
+}
+
+#pragma mark Properties
+
+- (NSURLSession *)associatedSession
+{
+    return _associatedSession;
+}
+
+- (NSURLSessionTask *)associatedSessionTask
+{
+    return _associatedSessionTask;
+}
+
+- (NSDictionary *)metadata
+{
+    return _stream.metadata.dictionary;
 }
 
 @end

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -23,7 +23,7 @@
 #import "SPDYMetadata.h"
 #import "SPDYOrigin.h"
 #import "SPDYOriginEndpoint.h"
-#import "SPDYProtocol.h"
+#import "SPDYProtocol+Project.h"
 #import "SPDYSettingsStore.h"
 #import "SPDYSocket.h"
 #import "SPDYStopwatch.h"


### PR DESCRIPTION
This change provides SPDY with with NSURLSession, NSURLSessionTask,
and associated configuration. This provides several benefits:

SPDY will have access to the app's delegate and operation queue, which
can be extended and used for additional callbacks, such as informing
the app a request is about to be dispatched to SPDY (implemented here),
or a new pushed stream was received (not yet implemented).

The NSURLSessionConfiguration is available, which Apple failed to
provided via the usual NSURLProtocol interfaces. This means we can
retrieve per-request cookie and cache configuration.

A new SPDYURLSessionDelegate extended delegate is now exposed. The app
may choose to implement this via the NSURLSession.delegate instance. It
will return the SPDYProtocol instance to the app, which can be used now
to directly retrieve the metadata, even in the cases where a NSURL-based
NSError is returned for the request. Previously it was impossible to
tell if CocoaSPDY serviced the request or not in this case (e.g.,
request timeouts).

Note: In order for this to work, the app must set the SPDYURLSession
property on the NSURLRequest instance prior to starting the request.
SPDY uses some indirection, to avoid serialization warnings when
caching the NSURLRequest, to store this reference.

Big thanks to @NSProgrammer for doing most of this work.