### PR TITLE
set lastUpgradeCheck & lastTestingUpgradeCheck to 630

### DIFF
--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -564,7 +564,8 @@
 		D2CC14A516179B43002E37CF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastTestingUpgradeCheck = 0630;
+				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = Twitter;
 			};
 			buildConfigurationList = D2CC14A816179B43002E37CF /* Build configuration list for PBXProject "SPDY" */;

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.iphoneos.arm64.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.iphoneos.arm64.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.iphoneos.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.iphoneos.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.iphonesimulator.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.iphonesimulator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.macosx.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.macosx.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDY.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPDY.xcodeproj/xcshareddata/xcschemes/SPDYUnitTests.xcscheme
+++ b/SPDY.xcodeproj/xcshareddata/xcschemes/SPDYUnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
silences the warnings about upgrading when using Xcode 6.3 & Xcode 6.3.1