### PR TITLE
Fix SPDYSessionManager reachability.

### DIFF
--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -347,6 +347,15 @@ typedef enum {
 */
 @property NSInteger proxyPort;
 
+/**
+  Set whether a session is moved to the correct pool or not.
+ 
+  Default is NO. If YES, a new session will be moved to the correct pool based
+  on whether it used WIFI or WWAN. This is an advanced setting for
+  experimentation and may be removed in the future.
+*/
+@property BOOL enforceSessionPoolCorrectness;
+
 @end
 
 /**

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -603,6 +603,7 @@ static SPDYConfiguration *defaultConfiguration;
     defaultConfiguration.enableProxy = YES;
     defaultConfiguration.proxyHost = nil;
     defaultConfiguration.proxyPort = 0;
+    defaultConfiguration.enforceSessionPoolCorrectness = NO;
 }
 
 + (SPDYConfiguration *)defaultConfiguration
@@ -624,6 +625,7 @@ static SPDYConfiguration *defaultConfiguration;
     copy.enableProxy = _enableProxy;
     copy.proxyHost = _proxyHost;
     copy.proxyPort = _proxyPort;
+    copy.enforceSessionPoolCorrectness = _enforceSessionPoolCorrectness;
     return copy;
 }
 

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -112,12 +112,12 @@
             _configuration = configuration;
             _socket = socket;
             _origin = origin;
-            SPDY_INFO(@"session connecting to %@", _origin);
+            SPDY_INFO(@"%@ connecting to %@", self, _origin);
 
             _cellular = cellular;
 
             if ([_origin.scheme isEqualToString:@"https"]) {
-                SPDY_DEBUG(@"session using TLS");
+                SPDY_DEBUG(@"%@ using TLS", self);
                 [_socket secureWithTLS:configuration.tlsSettings];
             }
 
@@ -292,11 +292,11 @@
 - (void)socket:(SPDYSocket *)socket didConnectToHost:(NSString *)host port:(in_port_t)port
 {
     [_connectedStopwatch reset];
-    SPDY_INFO(@"session connected to %@ (%@:%u)", _origin, host, port);
+    SPDY_INFO(@"%@ connected to %@ (%@:%u)", self, _origin, host, port);
 
     if (_cellular != socket.isCellular) {
-        SPDY_WARNING(@"session expected network type %@ but socket is %@",
-                _cellular ? @"cellular" : @"wifi",
+        SPDY_WARNING(@"%@ expected network type %@ but socket is %@",
+                self, _cellular ? @"cellular" : @"wifi",
                 socket.isCellular ? @"cellular" : @"wifi");
 
         _cellular = socket.isCellular;
@@ -374,7 +374,7 @@
 
 - (void)socket:(SPDYSocket *)socket willDisconnectWithError:(NSError *)error
 {
-    SPDY_WARNING(@"session connection error: %@", error);
+    SPDY_WARNING(@"%@ connection error: %@", error, self);
     for (SPDYStream *stream in _activeStreams) {
         stream.delegate = nil;
         [stream closeWithError:error];
@@ -384,7 +384,7 @@
 
 - (void)socketDidDisconnect:(SPDYSocket *)socket
 {
-    SPDY_INFO(@"session connection closed");
+    SPDY_INFO(@"%@ connection closed", self);
 
     _connected = NO;
     _disconnected = YES;


### PR DESCRIPTION
Change bf69dc5 "Increase unit test coverage" introduced a bug to how
we track current reachability (wifi, wwan) in SPDYSessionManager. It
failed to pass the correct value when being updated via callback.

A lot of code here is unnecessary, so this change removes much of that
in order to simplify. There are no more global variables or +initialize
code. Each instance of SPDYSessionManager manages its own reachability now.

This also allows the new behavior of moving a session to the correct pool to be
configurable.