### PR TITLE
Fast fail requests when no sessions available

### DIFF
--- a/SPDY/SPDYMetadata+Utils.h
+++ b/SPDY/SPDYMetadata+Utils.h
@@ -22,7 +22,9 @@
 @property (nonatomic) NSInteger latencyMs;
 @property (nonatomic) SPDYProxyStatus proxyStatus;
 @property (nonatomic) NSUInteger rxBytes;
+@property (nonatomic) NSUInteger rxBodyBytes;
 @property (nonatomic) NSUInteger txBytes;
+@property (nonatomic) NSUInteger txBodyBytes;
 @property (nonatomic) NSUInteger streamId;
 @property (nonatomic, copy) NSString *version;
 @property (nonatomic) BOOL viaProxy;

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -57,8 +57,14 @@ typedef enum {
 // SPDY stream bytes received. Includes all SPDY headers and bodies.
 @property (nonatomic, readonly) NSUInteger rxBytes;
 
+// SPDY stream bytes received for the body only, including framing.
+@property (nonatomic, readonly) NSUInteger rxBodyBytes;
+
 // SPDY stream bytes transmitted. Includes all SPDY headers and bodies.
 @property (nonatomic, readonly) NSUInteger txBytes;
+
+// SPDY stream bytes transmitted for the body only, including framing.
+@property (nonatomic, readonly) NSUInteger txBodyBytes;
 
 // SPDY request stream id, e.g. "1"
 @property (nonatomic, readonly) NSUInteger streamId;

--- a/SPDY/SPDYSession.h
+++ b/SPDY/SPDYSession.h
@@ -22,7 +22,7 @@
 - (void)session:(SPDYSession *)session capacityIncreased:(NSUInteger)capacity;
 - (void)session:(SPDYSession *)session connectedToNetwork:(bool)cellular;
 - (void)session:(SPDYSession *)session refusedStream:(SPDYStream *)stream;
-- (void)sessionClosed:(SPDYSession *)session;
+- (void)sessionClosed:(SPDYSession *)session error:(NSError *)error;
 @end
 
 @interface SPDYSession : NSObject

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -55,6 +55,7 @@
     SPDYFrameEncoder *_frameEncoder;
     SPDYStreamManager *_activeStreams;
     SPDYSocket *_socket;
+    NSError *_socketError;
     NSMutableData *_inputBuffer;
 
     SPDYStreamId _lastGoodStreamId;
@@ -375,6 +376,7 @@
 - (void)socket:(SPDYSocket *)socket willDisconnectWithError:(NSError *)error
 {
     SPDY_WARNING(@"%@ connection error: %@", self, error);
+    _socketError = error;
     for (SPDYStream *stream in _activeStreams) {
         stream.delegate = nil;
         [stream closeWithError:error];
@@ -390,7 +392,7 @@
     _disconnected = YES;
     _socket = nil;
 
-    [_delegate sessionClosed:self];
+    [_delegate sessionClosed:self error:_socketError];
     _delegate = nil;
 }
 
@@ -775,7 +777,7 @@
         [_activeStreams removeStreamForProtocol:stream.protocol];
     }
 
-    [_delegate sessionClosed:self];
+    [_delegate sessionClosed:self error:nil];
     _delegate = nil;
 
     if (_activeStreams.count == 0) {

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -441,6 +441,7 @@
     // below for partial data frame chunking. Don't double-add.
     if (stream) {
         stream.metadata.rxBytes += dataFrame.encodedLength;
+        stream.metadata.rxBodyBytes += dataFrame.encodedLength;
         if (stream.metadata.timeStreamResponseFirstData == 0) {
             stream.metadata.timeStreamResponseFirstData = [SPDYStopwatch currentSystemTime];
         }
@@ -984,6 +985,7 @@
             // On-the-wire byte accounting
             if (result > 0) {
                 stream.metadata.txBytes += result;
+                stream.metadata.txBodyBytes += result;
             }
 
             // SPDY window accounting
@@ -1021,6 +1023,7 @@
 
         if (result > 0) {
             stream.metadata.txBytes += result;
+            stream.metadata.txBodyBytes += result;
         }
         stream.localSideClosed = YES;
     }

--- a/SPDY/SPDYSessionManager.m
+++ b/SPDY/SPDYSessionManager.m
@@ -33,7 +33,7 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
 @interface SPDYSessionManager () <SPDYSessionDelegate, SPDYStreamDelegate>
 - (void)session:(SPDYSession *)session capacityIncreased:(NSUInteger)capacity;
 - (void)session:(SPDYSession *)session connectedToNetwork:(bool)cellular;
-- (void)sessionClosed:(SPDYSession *)session;
+- (void)sessionClosed:(SPDYSession *)session error:(NSError *)error;
 - (void)streamCanceled:(SPDYStream *)stream;
 @end
 
@@ -191,12 +191,7 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
 
         if (!session || error) {
             if (sessionPool.count == 0) {
-                for (SPDYStream *stream in _pendingStreams) {
-                    stream.delegate = nil;
-                    SPDYProtocol *protocol = stream.protocol;
-                    [protocol.client URLProtocol:protocol didFailWithError:error];
-                }
-                [_pendingStreams removeAllStreams];
+                [self _failPendingStreamsWithError:error];
                 return;
             } else {
                 SPDY_WARNING(@"failed allocating extra session to pool: %@", error);
@@ -260,6 +255,16 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
     }
 }
 
+- (void)_failPendingStreamsWithError:(NSError *)error
+{
+    for (SPDYStream *stream in _pendingStreams) {
+        stream.delegate = nil;
+        SPDYProtocol *protocol = stream.protocol;
+        [protocol.client URLProtocol:protocol didFailWithError:error];
+    }
+    [_pendingStreams removeAllStreams];
+}
+
 #pragma mark SPDYSessionDelegate
 
 - (void)session:(SPDYSession *)session capacityIncreased:(NSUInteger)capacity
@@ -302,9 +307,9 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
     [self _dispatch];
 }
 
-- (void)sessionClosed:(SPDYSession *)session
+- (void)sessionClosed:(SPDYSession *)session error:(NSError *)error
 {
-    SPDY_DEBUG(@"%@ closed", session);
+    SPDY_DEBUG(@"%@ closed, error %@", session, error);
 
     if ([_basePool contains:session]) {
         [_basePool remove:session];
@@ -312,10 +317,12 @@ static void SPDYReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkR
         [_wwanPool remove:session];
     }
 
-//    SPDYSessionPool * __strong *pool = session.isCellular ? &_wwanPool : &_basePool;
-//    if (*pool && [*pool remove:session] == 0) {
-//        *pool = nil;
-//    }
+    bool cellular = _cellular;
+    SPDYSessionPool *activePool = cellular ? _wwanPool : _basePool;
+    if (activePool.count == 0 && _pendingStreams.count > 0) {
+        [self _failPendingStreamsWithError:error];
+    }
+
 }
 
 - (void)session:(SPDYSession *)session refusedStream:(SPDYStream *)stream

--- a/SPDYUnitTests/SPDYMetadataTest.m
+++ b/SPDYUnitTests/SPDYMetadataTest.m
@@ -34,7 +34,9 @@
     metadata.streamId = 1;
     metadata.latencyMs = 100;
     metadata.txBytes = 200;
+    metadata.txBodyBytes = 150;
     metadata.rxBytes = 300;
+    metadata.rxBodyBytes = 250;
     metadata.cellular = YES;
     metadata.blockedMs = 400;
     metadata.connectedMs = 500;
@@ -53,7 +55,9 @@
     STAssertEquals(metadata.streamId, (NSUInteger)1, nil);
     STAssertEquals(metadata.latencyMs, (NSInteger)100, nil);
     STAssertEquals(metadata.txBytes, (NSUInteger)200, nil);
+    STAssertEquals(metadata.txBodyBytes, (NSUInteger)150, nil);
     STAssertEquals(metadata.rxBytes, (NSUInteger)300, nil);
+    STAssertEquals(metadata.rxBodyBytes, (NSUInteger)250, nil);
     STAssertEquals(metadata.cellular, YES, nil);
     STAssertEquals(metadata.blockedMs, (NSUInteger)400, nil);
     STAssertEquals(metadata.connectedMs, (NSUInteger)500, nil);


### PR DESCRIPTION
When there are pending streams waiting to be dispatched, and all sessions in the pool end up failing to connect, then we should fail the pending streams. There was a bug there where those streams would sit in the queue indefinitely, until they either timed out or another stream was enqueued (forcing a dispatch).

Also add some more metadata.
