### PR TITLE
Fix rxBytes and rxBodyBytes in metadata.

### DIFF
--- a/SPDY/SPDYFrame.h
+++ b/SPDY/SPDYFrame.h
@@ -25,6 +25,10 @@
 @property (nonatomic, strong) NSData *data;
 @property (nonatomic) SPDYStreamId streamId;
 @property (nonatomic) bool last;
+
+// Set to 0 for data frames that are synthesized from partial TCP reads of the
+// on-the-wire data frame, except for the first one of such a series.
+@property (nonatomic) NSUInteger headerLength;
 @end
 
 @interface SPDYSynStreamFrame : SPDYHeaderBlockFrame

--- a/SPDY/SPDYFrameDecoder.m
+++ b/SPDY/SPDYFrameDecoder.m
@@ -359,11 +359,19 @@ SPDYCommonHeader getCommonHeader(uint8_t *buffer) {
         return 0;
     }
 
-    SPDYDataFrame *frame = [[SPDYDataFrame alloc] initWithLength:SPDY_COMMON_HEADER_SIZE + _length];
+    // Some definitions for clarity:
+    // _length is remaining bytes of DATA frame
+    // _header.length is total bytes of DATA frame
+    // len is current buffer size (TCP segment)
+    // SPDYDataFrame.encodedLength will always represent the total size of the DATA frame
+
+    SPDYDataFrame *frame = [[SPDYDataFrame alloc] initWithLength:SPDY_COMMON_HEADER_SIZE + _header.length];
     frame.streamId = streamId;
     frame.data = [[NSData alloc] initWithBytesNoCopy:buffer
                                               length:bytesToRead
                                         freeWhenDone:NO];
+    // If first frame of many synthesized ones, or the entire frame, include headers in size
+    frame.headerLength = (_header.length == _length) ? SPDY_COMMON_HEADER_SIZE : 0;
 
     bytesRead = bytesToRead;
     _length -= bytesToRead;


### PR DESCRIPTION
Data frames were incorrectly reporting their size in the metadata
fields rxBytes and rxBodyBytes. If a data frame got broken up into
multiple TCP segments, those would each be reported to the SPDYSession
as a "data frame", with the encodedLength set to the overall frame
size (for the first segment) or the remaining segment sizes.

It was, essentially, indeterminately wrong from the POV of the app.
