### PR TITLE
Strip Authorization header on 302 redirect

### DIFF
--- a/SPDY/SPDYStream.m
+++ b/SPDY/SPDYStream.m
@@ -449,6 +449,7 @@
             [redirect setValue:nil forHTTPHeaderField:@"content-md5"];
             [redirect setValue:nil forHTTPHeaderField:@"content-range"];
             [redirect setValue:nil forHTTPHeaderField:@"content-type"];
+            [redirect setValue:nil forHTTPHeaderField:@"Authorization"];
             redirect.HTTPBody = nil;
             redirect.HTTPBodyStream = nil;
             redirect.SPDYBodyFile = nil;


### PR DESCRIPTION
A 302 redirect copies all of the headers from the original request, we should strip Authorization, because it shouldn't be included in the redirect's header since it was only relevant to the original request.
