### PR TITLE
Return default metadata from SPDYProtocolContext.

### DIFF
--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -386,8 +386,10 @@ typedef enum {
 /**
   Get the SPDY metadata from a protocol instance. This should only be called
   once a request has either completed or returned an error. Use at any other
-  time has undefined behavior. The use of this, metadataForResponse, and
-  metadataForError are all interchangeable.
+  time may result in unexpected values. It may be called inside the
+  URLSession:task:didStartLoadingRequest:withContext: callback, though only
+  the version will be populated. Metadata will never be nil. The use of this,
+  metadataForResponse, and metadataForError are all interchangeable.
  */
 - (SPDYMetadata *)metadata;
 

--- a/SPDY/SPDYProtocol.m
+++ b/SPDY/SPDYProtocol.m
@@ -132,6 +132,11 @@ static dispatch_once_t initConfig;
 
 - (SPDYMetadata *)metadata
 {
+    // Provide a default metadata (to at least indicate SPDY version) if stream has not yet started.
+    // This will get replaced with the real metadata if/when it becomes available.
+    if (_metadata == nil) {
+        _metadata = [[SPDYMetadata alloc] init];
+    }
     return _metadata;
 }
 

--- a/SPDYUnitTests/SPDYProtocolContextTest.m
+++ b/SPDYUnitTests/SPDYProtocolContextTest.m
@@ -18,6 +18,7 @@
 @implementation SPDYProtocolContextTest
 {
     id<SPDYProtocolContext> _spdyContext;
+    SPDYMetadata *_spdyMetadataAtTimeOfCallback;
 }
 
 - (void)tearDown
@@ -28,6 +29,7 @@
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didStartLoadingRequest:(NSURLRequest *)request withContext:(id<SPDYProtocolContext>)context
 {
     _spdyContext = context;
+    _spdyMetadataAtTimeOfCallback = [context metadata];
 }
 
 - (void)testSPDYProtocolContextDoesProvideMetadata
@@ -58,9 +60,14 @@
 
     XCTAssertNotNil(_spdyContext, @"URLSession:task:didStartLoadingRequest:withContext delegate not called");
 
+    XCTAssertNotNil(_spdyMetadataAtTimeOfCallback, @"Metadata should be provided at time of context");
+    XCTAssertEqualObjects(_spdyMetadataAtTimeOfCallback.version, @"3.1");
+    XCTAssertEqual(_spdyMetadataAtTimeOfCallback.timeStreamCreated, (uint32_t)0);
+
     SPDYMetadata *metadata = [_spdyContext metadata];
     XCTAssertNotNil(metadata);
     XCTAssertEqualObjects(metadata.version, @"3.1");
+    XCTAssertGreaterThan(metadata.timeStreamCreated, 0);
 }
 
 @end


### PR DESCRIPTION
If stream hasn't started yet, provide a barebones default metadata.
