### PR TITLE
Add support for NSURLCache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 xcuserdata/
 contents.xcworkspacedata
 *.xccheckout
+*.gcda

--- a/SPDY.xcodeproj/project.pbxproj
+++ b/SPDY.xcodeproj/project.pbxproj
@@ -101,6 +101,9 @@
 		5C48CF8E1B0A684C0082F7EF /* SPDYCacheStoragePolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C48CF8C1B0A68400082F7EF /* SPDYCacheStoragePolicy.m */; };
 		5C48CF8F1B0A684C0082F7EF /* SPDYCacheStoragePolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C48CF8C1B0A68400082F7EF /* SPDYCacheStoragePolicy.m */; };
 		5C48CF901B0A684D0082F7EF /* SPDYCacheStoragePolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C48CF8C1B0A68400082F7EF /* SPDYCacheStoragePolicy.m */; };
+		5C5691E71C0D627400E47EAA /* SPDYMockSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5691E61C0D627400E47EAA /* SPDYMockSessionManager.m */; };
+		5C5691EA1C0D66F100E47EAA /* SPDYNSURLCachingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5691E91C0D66F100E47EAA /* SPDYNSURLCachingTest.m */; };
+		5C5691ED1C0E7E4400E47EAA /* SPDYIntegrationTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5691EC1C0E7E4400E47EAA /* SPDYIntegrationTestHelper.m */; };
 		5C5EA46E1A119B630058FB64 /* SPDYOriginEndpoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5EA46A1A119B630058FB64 /* SPDYOriginEndpoint.m */; };
 		5C5EA46F1A119B630058FB64 /* SPDYOriginEndpoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5EA46A1A119B630058FB64 /* SPDYOriginEndpoint.m */; };
 		5C5EA4701A119B630058FB64 /* SPDYOriginEndpoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5EA46A1A119B630058FB64 /* SPDYOriginEndpoint.m */; };
@@ -198,6 +201,11 @@
 		5C427F101A1D57890072403D /* SPDYStopwatchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYStopwatchTest.m; sourceTree = "<group>"; };
 		5C48CF8B1B0A68400082F7EF /* SPDYCacheStoragePolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYCacheStoragePolicy.h; sourceTree = "<group>"; };
 		5C48CF8C1B0A68400082F7EF /* SPDYCacheStoragePolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYCacheStoragePolicy.m; sourceTree = "<group>"; };
+		5C5691E61C0D627400E47EAA /* SPDYMockSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYMockSessionManager.m; sourceTree = "<group>"; };
+		5C5691E81C0D62D200E47EAA /* SPDYMockSessionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDYMockSessionManager.h; sourceTree = "<group>"; };
+		5C5691E91C0D66F100E47EAA /* SPDYNSURLCachingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYNSURLCachingTest.m; sourceTree = "<group>"; };
+		5C5691EC1C0E7E4400E47EAA /* SPDYIntegrationTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYIntegrationTestHelper.m; sourceTree = "<group>"; };
+		5C5691EE1C0E7E8000E47EAA /* SPDYIntegrationTestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDYIntegrationTestHelper.h; sourceTree = "<group>"; };
 		5C5EA4691A119B630058FB64 /* SPDYOriginEndpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYOriginEndpoint.h; sourceTree = "<group>"; };
 		5C5EA46A1A119B630058FB64 /* SPDYOriginEndpoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDYOriginEndpoint.m; sourceTree = "<group>"; };
 		5C5EA4711A119C950058FB64 /* SPDYMockOriginEndpointManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDYMockOriginEndpointManager.h; sourceTree = "<group>"; };
@@ -300,6 +308,7 @@
 				069AA03816975B65005A72CA /* SPDYFrameCodecTest.m */,
 				5C2A211C19F9CA0E00D0EA76 /* SPDYLoggingTest.m */,
 				5CF0A2C81A089BC500B6D141 /* SPDYMetadataTest.m */,
+				5C5691E91C0D66F100E47EAA /* SPDYNSURLCachingTest.m */,
 				5C04570419B043CB009E0AC2 /* SPDYOriginEndpointTest.m */,
 				0679F3CE186217FC006F122E /* SPDYOriginTest.m */,
 				5CC7B9041BDECD43006E2952 /* SPDYProtocolContextTest.m */,
@@ -334,10 +343,14 @@
 				5C5EA4721A119C950058FB64 /* SPDYMockOriginEndpointManager.m */,
 				7774C7E1AF717FC36B7F15B6 /* SPDYSocket+SPDYSocketMock.h */,
 				7774C0ECD0C6E5D73FB38752 /* SPDYSocket+SPDYSocketMock.m */,
+				5C5691E81C0D62D200E47EAA /* SPDYMockSessionManager.h */,
+				5C5691E61C0D627400E47EAA /* SPDYMockSessionManager.m */,
 				7774CFEA3D0DAF374D7C7654 /* SPDYMockSessionTestBase.h */,
 				7774C193AC525BC3A79F2853 /* SPDYMockSessionTestBase.m */,
 				5CF0A2CA1A0952BA00B6D141 /* SPDYMockURLProtocolClient.h */,
 				5CF0A2CB1A0952D900B6D141 /* SPDYMockURLProtocolClient.m */,
+				5C5691EC1C0E7E4400E47EAA /* SPDYIntegrationTestHelper.m */,
+				5C5691EE1C0E7E8000E47EAA /* SPDYIntegrationTestHelper.h */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -678,6 +691,7 @@
 			files = (
 				5C6D809A1BC44C19003AF2E0 /* SPDYURLCacheTest.m in Sources */,
 				5C0456FF19B033E9009E0AC2 /* SPDYSocketOps.m in Sources */,
+				5C5691ED1C0E7E4400E47EAA /* SPDYIntegrationTestHelper.m in Sources */,
 				06FDA20616717DF100137DBD /* SPDYSocket.m in Sources */,
 				5CA0B9C81A6486F10068ABD9 /* SPDYSettingsStoreTest.m in Sources */,
 				5C210A0A1A5F48C500ADB538 /* SPDYSessionPool.m in Sources */,
@@ -686,6 +700,7 @@
 				06FDA20B16717DF100137DBD /* SPDYFrameDecoder.m in Sources */,
 				0679F3CF186217FC006F122E /* SPDYOriginTest.m in Sources */,
 				06FDA20D16717DF100137DBD /* SPDYProtocol.m in Sources */,
+				5C5691E71C0D627400E47EAA /* SPDYMockSessionManager.m in Sources */,
 				5C750B501A390C7200CC0F2F /* SPDYPushStreamManagerTest.m in Sources */,
 				06FDA20F16717DF100137DBD /* SPDYSession.m in Sources */,
 				06FDA21116717DF100137DBD /* SPDYSessionManager.m in Sources */,
@@ -711,6 +726,7 @@
 				067EBFE717418F350029F16C /* SPDYStreamTest.m in Sources */,
 				062EA642175D4CD3003BC1CE /* SPDYCommonLogger.m in Sources */,
 				5C5EA46E1A119B630058FB64 /* SPDYOriginEndpoint.m in Sources */,
+				5C5691EA1C0D66F100E47EAA /* SPDYNSURLCachingTest.m in Sources */,
 				5C6D80AB1BC457B3003AF2E0 /* SPDYCanonicalRequest.m in Sources */,
 				25959A3F1937DE3900FC9731 /* SPDYSessionManagerTest.m in Sources */,
 				5CE43CE11AD74FC900E73FAC /* SPDYMetadata+Utils.m in Sources */,

--- a/SPDY/SPDYCacheStoragePolicy.h
+++ b/SPDY/SPDYCacheStoragePolicy.h
@@ -24,3 +24,13 @@
  *  \returns A cache storage policy to use.
  */
 extern NSURLCacheStoragePolicy SPDYCacheStoragePolicy(NSURLRequest *request, NSHTTPURLResponse *response);
+
+typedef enum {
+    SPDYCachedResponseStateValid = 0,
+    SPDYCachedResponseStateInvalid,
+    SPDYCachedResponseStateMustRevalidate
+} SPDYCachedResponseState;
+
+/*! Determines the validity of a cached response 
+ */
+extern SPDYCachedResponseState SPDYCacheLoadingPolicy(NSURLRequest *request, NSCachedURLResponse *response);

--- a/SPDY/SPDYCacheStoragePolicy.m
+++ b/SPDY/SPDYCacheStoragePolicy.m
@@ -13,6 +13,59 @@
 
 #import "SPDYCacheStoragePolicy.h"
 
+typedef struct _HTTPTimeFormatInfo {
+    const char *readFormat;
+    const char *writeFormat;
+    BOOL usesHasTimezoneInfo;
+} HTTPTimeFormatInfo;
+
+static HTTPTimeFormatInfo kTimeFormatInfos[] =
+{
+    { "%a, %d %b %Y %H:%M:%S %Z", "%a, %d %b %Y %H:%M:%S GMT", YES }, // Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
+    { "%A, %d-%b-%y %H:%M:%S %Z", "%A, %d-%b-%y %H:%M:%S GMT", YES }, // Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC 1036
+    { "%a %b %e %H:%M:%S %Y", "%a %b %e %H:%M:%S %Y", NO },           // Sun Nov  6 08:49:37 1994       ; ANSI C's asctime() format
+};
+
+
+static NSDate *HTTPDateFromString(NSString *string)
+{
+    NSDate *date = nil;
+    if (string) {
+        struct tm parsedTime;
+        const char *utf8String = [string UTF8String];
+
+        for (int format = 0; (size_t)format < (sizeof(kTimeFormatInfos) / sizeof(kTimeFormatInfos[0])); format++) {
+            HTTPTimeFormatInfo info = kTimeFormatInfos[format];
+            if (info.readFormat != NULL && strptime(utf8String, info.readFormat, &parsedTime)) {
+                NSTimeInterval ti = (info.usesHasTimezoneInfo ? mktime(&parsedTime) : timegm(&parsedTime));
+                date = [NSDate dateWithTimeIntervalSince1970:ti];
+                if (date) {
+                    break;
+                }
+            }
+        }
+    }
+
+    return date;
+}
+
+NSDictionary *HTTPCacheControlParameters(NSString *cacheControl)
+{
+    if (cacheControl.length == 0) {
+        return nil;
+    }
+
+    NSArray *components = [cacheControl componentsSeparatedByString:@","];
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithCapacity:components.count];
+    for (NSString *component in components) {
+        NSArray *pair = [component componentsSeparatedByString:@"="];
+        NSString *key = [pair[0] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        NSString *value = pair.count == 2 ? [pair[1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] : @"";
+        parameters[key] = value;
+    }
+    return parameters;
+}
+
 extern NSURLCacheStoragePolicy SPDYCacheStoragePolicy(NSURLRequest *request, NSHTTPURLResponse *response)
 {
     bool                     cacheable;
@@ -35,6 +88,13 @@ extern NSURLCacheStoragePolicy SPDYCacheStoragePolicy(NSURLRequest *request, NSH
             break;
     }
 
+    // Let's only cache GET requests
+    if (cacheable) {
+        if (![request.HTTPMethod isEqualToString:@"GET"]) {
+            cacheable = NO;
+        }
+    }
+
     // If the response might be cacheable, look at the "Cache-Control" header in 
     // the response.
 
@@ -42,30 +102,37 @@ extern NSURLCacheStoragePolicy SPDYCacheStoragePolicy(NSURLRequest *request, NSH
     // string is nil, so we have to explicitly test for nil in the following two cases.
 
     if (cacheable) {
-        NSString *responseHeader;
+        NSString *cacheResponseHeader;
+        NSString *dateResponseHeader;
 
         for (NSString *key in [response.allHeaderFields allKeys]) {
             if ([key caseInsensitiveCompare:@"cache-control"] == NSOrderedSame) {
-                responseHeader = [response.allHeaderFields[key] lowercaseString];
-                break;
+                cacheResponseHeader = [response.allHeaderFields[key] lowercaseString];
+            }
+            else if ([key caseInsensitiveCompare:@"date"] == NSOrderedSame) {
+                dateResponseHeader = [response.allHeaderFields[key] lowercaseString];
             }
         }
 
-        if (responseHeader != nil && [responseHeader rangeOfString:@"no-store"].location != NSNotFound) {
+        if (cacheResponseHeader != nil && [cacheResponseHeader rangeOfString:@"no-store"].location != NSNotFound) {
+            cacheable = NO;
+        }
+
+        // Must have a Date header. Can't validate freshness otherwise.
+        if (dateResponseHeader == nil) {
             cacheable = NO;
         }
     }
 
     // If we still think it might be cacheable, look at the "Cache-Control" header in 
-    // the request.
+    // the request. Also rule out requests with Authorization in them.
 
     if (cacheable) {
         NSString *requestHeader;
 
         requestHeader = [[request valueForHTTPHeaderField:@"cache-control"] lowercaseString];
-        if (requestHeader != nil                                             &&
-            [requestHeader rangeOfString:@"no-store"].location != NSNotFound &&
-            [requestHeader rangeOfString:@"no-cache"].location != NSNotFound) {
+        if ((requestHeader != nil && [requestHeader rangeOfString:@"no-store"].location != NSNotFound) ||
+            [request valueForHTTPHeaderField:@"authorization"].length > 0) {
             cacheable = NO;
         }
     }
@@ -82,4 +149,72 @@ extern NSURLCacheStoragePolicy SPDYCacheStoragePolicy(NSURLRequest *request, NSH
     }
 
     return result;
+}
+
+extern SPDYCachedResponseState SPDYCacheLoadingPolicy(NSURLRequest *request, NSCachedURLResponse *response)
+{
+    if (request == nil || response == nil) {
+        return SPDYCachedResponseStateInvalid;
+    }
+
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response.response;
+    NSString *responseCacheControl;
+    NSDate *responseDate;
+
+    // Cached response validation
+
+    // Get header values
+    for (NSString *key in [httpResponse.allHeaderFields allKeys]) {
+        if ([key caseInsensitiveCompare:@"cache-control"] == NSOrderedSame) {
+            responseCacheControl = [httpResponse.allHeaderFields[key] lowercaseString];
+        }
+        else if ([key caseInsensitiveCompare:@"date"] == NSOrderedSame) {
+            NSString *dateString = httpResponse.allHeaderFields[key];
+            responseDate = HTTPDateFromString(dateString);
+        }
+    }
+
+    if (responseCacheControl == nil || responseDate == nil) {
+        return SPDYCachedResponseStateMustRevalidate;
+    }
+
+    if ([responseCacheControl rangeOfString:@"no-cache"].location != NSNotFound ||
+        [responseCacheControl rangeOfString:@"must-revalidate"].location != NSNotFound ||
+        [responseCacheControl rangeOfString:@"max-age=0"].location != NSNotFound) {
+        return SPDYCachedResponseStateMustRevalidate;
+    }
+
+    // Verify item has not expired
+    NSDictionary *cacheControlParams = HTTPCacheControlParameters(responseCacheControl);
+    if (cacheControlParams[@"max-age"] != nil) {
+        NSTimeInterval ageOfResponse = [[NSDate date] timeIntervalSinceDate:responseDate];
+        NSTimeInterval maxAge = [cacheControlParams[@"max-age"] doubleValue];
+        if (ageOfResponse > maxAge) {
+            return SPDYCachedResponseStateMustRevalidate;
+        }
+    } else {
+        // If no max-age, you have to revalidate
+        return SPDYCachedResponseStateMustRevalidate;
+    }
+
+    // Request validation
+
+    NSString *requestCacheControl = [[request valueForHTTPHeaderField:@"cache-control"] lowercaseString];
+
+    if (requestCacheControl != nil) {
+        if ([requestCacheControl rangeOfString:@"no-cache"].location != NSNotFound) {
+            return SPDYCachedResponseStateMustRevalidate;
+        }
+    }
+
+    // Note: there's a lot more validation we should do, to be a well-behaving user agent.
+    // We don't support Pragma header.
+    // We don't support Expires header.
+    // We don't support Vary header.
+    // We don't support ETag response header or If-None-Match request header.
+    // We don't support Last-Modified response header or If-Modified-Since request header.
+    // We don't look at more of the Cache-Control parameters, including ones that specify a field name.
+    // ...
+
+    return SPDYCachedResponseStateValid;
 }

--- a/SPDY/SPDYMetadata+Utils.h
+++ b/SPDY/SPDYMetadata+Utils.h
@@ -28,6 +28,7 @@
 @property (nonatomic) NSUInteger streamId;
 @property (nonatomic, copy) NSString *version;
 @property (nonatomic) BOOL viaProxy;
+@property (nonatomic) SPDYLoadSource loadSource;
 @property (nonatomic) NSTimeInterval timeSessionConnected;
 @property (nonatomic) NSTimeInterval timeStreamCreated;
 @property (nonatomic) NSTimeInterval timeStreamRequestStarted;

--- a/SPDY/SPDYProtocol.h
+++ b/SPDY/SPDYProtocol.h
@@ -42,6 +42,12 @@ typedef enum {
     SPDYProxyStatusConfigWithAuth   // info provided in SPDYConfiguration, proxy needs auth
 } SPDYProxyStatus;
 
+typedef enum {
+    SPDYLoadSourceNetwork = 0,      // regular stream or push stream from network
+    SPDYLoadSourceCache,            // from NSURLCache
+    SPDYLoadSourcePushCache         // from in-memory cache of in-progress pushed streams
+} SPDYLoadSource;
+
 @interface SPDYMetadata : NSObject
 
 // SPDY stream time spent blocked - while queued waiting for connection, flow control, etc.
@@ -85,6 +91,9 @@ typedef enum {
 
 // Indicates connection used a proxy server
 @property (nonatomic, readonly) BOOL viaProxy;
+
+// Indicates where this response came from
+@property (nonatomic, readonly) SPDYLoadSource loadSource;
 
 // The following measurements, presented in seconds, use mach_absolute_time() and are point-in-time
 // relative to whatever base mach_absolute_time() uses. They use the following function to convert

--- a/SPDY/SPDYPushStreamManager.m
+++ b/SPDY/SPDYPushStreamManager.m
@@ -12,6 +12,7 @@
 #import <objc/runtime.h>
 #import <Foundation/Foundation.h>
 #import "SPDYCommonLogger.h"
+#import "SPDYMetadata+Utils.h"
 #import "SPDYPushStreamManager.h"
 #import "SPDYProtocol.h"
 #import "SPDYStream.h"
@@ -271,6 +272,9 @@
             [self removeStream:stream];
         } else {
             SPDY_DEBUG(@"PUSH.%u: leaving pushed stream with associated stream %u", stream.streamId, stream.associatedStream.streamId);
+
+            // Transition load source of this stream since it is done pulling from network.
+            stream.metadata.loadSource = SPDYLoadSourcePushCache;
         }
     }
 }

--- a/SPDY/SPDYSession.m
+++ b/SPDY/SPDYSession.m
@@ -198,6 +198,7 @@
     stream.metadata.viaProxy = _socket.connectedToProxy;
     stream.metadata.proxyStatus = _socket.proxyStatus;
     stream.metadata.cellular = _cellular;
+    stream.metadata.loadSource = SPDYLoadSourceNetwork;
 
     [stream startWithStreamId:streamId
                sendWindowSize:_initialSendWindowSize

--- a/SPDY/SPDYSessionManager.h
+++ b/SPDY/SPDYSessionManager.h
@@ -11,7 +11,9 @@
 
 #import <Foundation/Foundation.h>
 
+@class SPDYOrigin;
 @class SPDYPushStreamManager;
+@class SPDYStream;
 
 @interface SPDYSessionManager : NSObject
 

--- a/SPDY/SPDYStream.m
+++ b/SPDY/SPDYStream.m
@@ -72,6 +72,10 @@
 
     NSURLRequest *_pushRequest;  // stored because we need a strong reference, _request is weak.
     NSHTTPURLResponse *_response;
+
+    NSURLCacheStoragePolicy _cachePolicy;
+    NSMutableData *_cacheDataBuffer; // only used for manual caching.
+    NSInteger _cacheMaxItemSize;
 }
 
 - (instancetype)initWithProtocol:(SPDYProtocol *)protocol
@@ -332,6 +336,9 @@
     [self markUnblocked];  // just in case. safe if already unblocked.
     _metadata.blockedMs = _blockedElapsed * 1000;
 
+    // Manually make the willCacheResponse callback when needed
+    [self _storeCacheResponse];
+
     [_client URLProtocolDidFinishLoading:_protocol];
 
     if (_delegate && [_delegate respondsToSelector:@selector(streamClosed:)]) {
@@ -585,11 +592,24 @@
         return;
     }
 
-    if (_client) {
-        NSURLCacheStoragePolicy cachePolicy = SPDYCacheStoragePolicy(_request, _response);
-        [_client URLProtocol:_protocol
-          didReceiveResponse:_response
-          cacheStoragePolicy:cachePolicy];
+    _cachePolicy = SPDYCacheStoragePolicy(_request, _response);
+    [_client URLProtocol:_protocol
+      didReceiveResponse:_response
+      cacheStoragePolicy:_cachePolicy];
+
+    // Prepare for manual caching, if needed
+    NSURLCache *cache = _protocol.associatedSession.configuration.URLCache;
+    if (_cachePolicy != NSURLCacheStorageNotAllowed &&  // cacheable?
+        [self _shouldUseManualCaching] &&                // hack needed and NSURLSession used?
+        cache != nil &&                                 // cache configured (NSURLSession-specific)?
+        _local) {                                       // not a push request?
+
+        // The NSURLCache has a heuristic to limit the max size of items based on the capacity of the
+        // cache. This is our attempt to mimic that behavior and prevent unlimited buffering of large
+        // responses. These numbers were found by manually experimenting and are only approximate.
+        // See SPDYNSURLCachingTest testResponseNearItemCacheSize_DoesUseCache.
+        _cacheDataBuffer = [[NSMutableData alloc] init];
+        _cacheMaxItemSize = MAX(cache.memoryCapacity * 0.05, cache.diskCapacity * 0.01);
     }
 }
 
@@ -689,7 +709,7 @@
             NSUInteger inflatedLength = DECOMPRESSED_CHUNK_LENGTH - _zlibStream.avail_out;
             inflatedData.length = inflatedLength;
             if (inflatedLength > 0) {
-                [_client URLProtocol:_protocol didLoadData:inflatedData];
+                [self _didLoadDataChunk:inflatedData];
             }
 
             // This can happen if the decompressed data is size N * DECOMPRESSED_CHUNK_LENGTH,
@@ -711,7 +731,77 @@
         }
     } else {
         NSData *dataCopy = [[NSData alloc] initWithBytes:data.bytes length:dataLength];
-        [_client URLProtocol:_protocol didLoadData:dataCopy];
+        [self _didLoadDataChunk:dataCopy];
+    }
+}
+
+- (void)_didLoadDataChunk:(NSData *)data
+{
+    [_client URLProtocol:_protocol didLoadData:data];
+
+    if (_cacheDataBuffer) {
+        NSUInteger bufferSize = _cacheDataBuffer.length + data.length;
+        if (bufferSize < _cacheMaxItemSize) {
+            [_cacheDataBuffer appendData:data];
+        } else {
+            // Throw away anything already buffered, it's going to be too big
+            _cacheDataBuffer = nil;
+        }
+    }
+}
+
+// NSURLSession on iOS 8 and iOS 7 does not cache items. Seems to be a bug with its interation
+// with NSURLProtocol. This flag represents whether our workaround, to insert into the cache
+// ourselves, is turned on.
+- (bool)_shouldUseManualCaching
+{
+    NSInteger osVersion = 0;
+    NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+    if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
+        osVersion = [processInfo operatingSystemVersion].majorVersion;
+    }
+
+    // iOS 8 and earlier and using NSURLSession
+    return (osVersion <= 8 && _protocol.associatedSession != nil && _protocol.associatedSessionTask != nil);
+}
+
+- (void)_storeCacheResponse
+{
+    if (_cacheDataBuffer == nil) {
+        return;
+    }
+
+    NSCachedURLResponse *cachedResponse;
+    cachedResponse = [[NSCachedURLResponse alloc] initWithResponse:_response
+                                                              data:_cacheDataBuffer
+                                                          userInfo:nil
+                                                     storagePolicy:_cachePolicy];
+    NSURLCache *cache = _protocol.associatedSession.configuration.URLCache;
+    NSURLSessionDataTask *dataTask = (NSURLSessionDataTask *)_protocol.associatedSessionTask;
+
+    // Make "official" willCacheResponse callback to app, bypassing the NSURL loading system.
+    id<NSURLSessionDataDelegate> delegate = (id)_protocol.associatedSession.delegate;
+    if ([delegate respondsToSelector:@selector(URLSession:dataTask:willCacheResponse:completionHandler:)]) {
+        NSOperationQueue *queue = _protocol.associatedSession.delegateQueue;
+        [(queue) ?: [NSOperationQueue mainQueue] addOperationWithBlock:^{
+            [delegate URLSession:_protocol.associatedSession dataTask:dataTask willCacheResponse:cachedResponse completionHandler:^(NSCachedURLResponse * cachedResponse) {
+                // This block may execute asynchronously at any time. No need to come back to the SPDY/NSURL thread
+                if (cachedResponse) {
+                    if ([cache respondsToSelector:@selector(storeCachedResponse:forDataTask:)]) {
+                        [cache storeCachedResponse:cachedResponse forDataTask:dataTask];
+                    } else {
+                        [cache storeCachedResponse:cachedResponse forRequest:_request];
+                    }
+                }
+            }];
+        }];
+    } else {
+        // willCacheResponse delegate not implemented. Default behavior is to cache.
+        if ([cache respondsToSelector:@selector(storeCachedResponse:forDataTask:)]) {
+            [cache storeCachedResponse:cachedResponse forDataTask:dataTask];
+        } else {
+            [cache storeCachedResponse:cachedResponse forRequest:_request];
+        }
     }
 }
 

--- a/SPDYUnitTests/SPDYIntegrationTestHelper.h
+++ b/SPDYUnitTests/SPDYIntegrationTestHelper.h
@@ -29,11 +29,13 @@
 - (BOOL)didLoadFromNetwork;
 - (BOOL)didLoadFromCache;
 - (BOOL)didGetResponse;
+- (BOOL)didLoadData;
 - (BOOL)didGetError;
 - (BOOL)didCacheResponse;
 
 - (void)reset;
 - (void)loadRequest:(NSURLRequest *)request;
+- (void)provideResponseWithStatus:(NSUInteger)status cacheControl:(NSString *)cacheControl date:(NSDate *)date dataChunks:(NSArray *)dataChunks;
 - (void)provideResponseWithStatus:(NSUInteger)status cacheControl:(NSString *)cacheControl date:(NSDate *)date;
 - (void)provideBasicUncacheableResponse;
 - (void)provideBasicCacheableResponse;

--- a/SPDYUnitTests/SPDYIntegrationTestHelper.h
+++ b/SPDYUnitTests/SPDYIntegrationTestHelper.h
@@ -1,0 +1,53 @@
+//
+//  SPDYIntegrationTestHelper.h
+//  SPDY
+//
+//  Copyright (c) 2015 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier on 11/30/15.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SPDYStream;
+@protocol SPDYProtocolContext;
+
+// Base class. Should use one of the specific implementations below.
+@interface SPDYIntegrationTestHelper : NSObject
+
+@property (nonatomic) SPDYStream *stream;
+@property (nonatomic) NSCachedURLResponse *willCacheResponse;
+@property (nonatomic) NSHTTPURLResponse *response;
+@property (nonatomic) NSMutableData *data;
+@property (nonatomic) NSError *connectionError;
+
++ (void)setUp;
++ (void)tearDown;
+
+- (BOOL)didLoadFromNetwork;
+- (BOOL)didLoadFromCache;
+- (BOOL)didGetResponse;
+- (BOOL)didGetError;
+- (BOOL)didCacheResponse;
+
+- (void)reset;
+- (void)loadRequest:(NSURLRequest *)request;
+- (void)provideResponseWithStatus:(NSUInteger)status cacheControl:(NSString *)cacheControl date:(NSDate *)date;
+- (void)provideBasicUncacheableResponse;
+- (void)provideBasicCacheableResponse;
+- (void)provideErrorResponse;
+
+@end
+
+// Request helper that uses NSURLConnection to issue requests.
+@interface SPDYURLConnectionIntegrationTestHelper : SPDYIntegrationTestHelper<NSURLConnectionDelegate, NSURLConnectionDataDelegate>
+@end
+
+// Request helper that uses NSURLSession (data task) to issue requests.
+@interface SPDYURLSessionIntegrationTestHelper : SPDYIntegrationTestHelper<NSURLSessionDataDelegate>
+@property (nonatomic) id<SPDYProtocolContext> spdyContext;
+@end
+
+

--- a/SPDYUnitTests/SPDYIntegrationTestHelper.m
+++ b/SPDYUnitTests/SPDYIntegrationTestHelper.m
@@ -1,0 +1,300 @@
+//
+//  SPDYIntegrationTestHelper.h
+//  SPDY
+//
+//  Copyright (c) 2015 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier on 11/30/15.
+//
+
+#import "NSURLRequest+SPDYURLRequest.h"
+#import "SPDYIntegrationTestHelper.h"
+#import "SPDYMockSessionManager.h"
+#import "SPDYProtocol.h"
+#import "SPDYStream.h"
+
+#pragma mark Base implementation
+
+@implementation SPDYIntegrationTestHelper
+{
+    CFRunLoopRef _runLoop;
+}
+
++ (void)setUp
+{
+    [SPDYMockSessionManager performSwizzling:YES];
+}
+
++ (void)tearDown
+{
+    [SPDYMockSessionManager performSwizzling:NO];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self != nil) {
+        [self provideErrorResponse];
+    }
+    return self;
+}
+
+- (BOOL)didLoadFromNetwork
+{
+    return self.didGetResponse && _stream != nil;
+}
+
+- (BOOL)didLoadFromCache
+{
+    return self.didGetResponse && _stream == nil;
+}
+
+- (BOOL)didGetResponse
+{
+    return _response != nil;
+}
+
+- (BOOL)didGetError
+{
+    return _connectionError != nil;
+}
+
+- (BOOL)didCacheResponse
+{
+    return _willCacheResponse != nil;
+}
+
+- (void)reset
+{
+    _stream = nil;
+    _response = nil;
+    _data = nil;
+    _willCacheResponse = nil;
+    _connectionError = nil;
+}
+
+- (void)loadRequest:(NSURLRequest *)request
+{
+    [self reset];
+
+    // Needs to be implemented by subclass as well
+}
+
+- (NSString *)dateHeaderValue:(NSDate *)date
+{
+    NSString *string = nil;
+    if (date) {
+        time_t timeRaw = (long)date.timeIntervalSince1970;
+        struct tm timeStruct;
+        char buffer[80];
+
+        gmtime_r(&timeRaw, &timeStruct);
+        size_t charCount = strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S GMT", &timeStruct);
+        if (0 != charCount) {
+            string = [[NSString alloc] initWithCString:buffer encoding:NSASCIIStringEncoding];
+        }
+    }
+
+    return string;
+}
+
+- (void)provideResponseWithStatus:(NSUInteger)status cacheControl:(NSString *)cacheControl date:(NSDate *)date
+{
+    [SPDYMockSessionManager shared].streamQueuedBlock = ^(SPDYStream *stream) {
+        _stream = stream;
+        uint8_t dataBytes[] = {1};
+        NSData *data = [NSData dataWithBytes:dataBytes length:1];
+        NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithDictionary:@{
+                @":status": [@(status) stringValue],
+                @":version": @"1.1",
+                }];
+        if (date != nil) {
+            headers[@"Date"] = [self dateHeaderValue:date];
+        }
+        if (cacheControl.length > 0) {
+            headers[@"Cache-Control"] = cacheControl;
+        }
+
+        [stream mergeHeaders:headers];
+        [stream didReceiveResponse];
+        [stream didLoadData:data];
+    };
+}
+
+- (void)provideBasicUncacheableResponse
+{
+    [self provideResponseWithStatus:200 cacheControl:@"no-store, no-cache, must-revalidate" date:[NSDate date]];
+}
+
+- (void)provideBasicCacheableResponse
+{
+    [self provideResponseWithStatus:200 cacheControl:@"public, max-age=1200" date:[NSDate date]];
+}
+
+- (void)provideErrorResponse
+{
+    [SPDYMockSessionManager shared].streamQueuedBlock = ^(SPDYStream *stream) {
+        _stream = stream;
+        [stream closeWithError:[NSError errorWithDomain:@"SPDYUnitTest" code:1ul userInfo:nil]];
+    };
+}
+
+- (void)_waitForRequestToFinish
+{
+    _runLoop = CFRunLoopGetCurrent();
+    CFRunLoopRun();
+}
+
+- (void)_finishRequest
+{
+    CFRunLoopStop(_runLoop);
+}
+
+- (NSString *)description
+{
+    NSDictionary *params = @{
+                             @"didLoadFromNetwork": @([self didLoadFromNetwork]),
+                             @"didGetResponse": @([self didGetResponse]),
+                             @"didGetError": @([self didGetError]),
+                             @"didCacheResponse": @([self didCacheResponse]),
+                             @"stream": _stream ?: @"<nil>",
+                             @"response": _response ?: @"<nil>",
+                             @"willCacheResponse": _willCacheResponse ?: @"<nil>",
+                             @"connectionError": _connectionError ?: @"<nil>",
+                             };
+    return [NSString stringWithFormat:@"<%@: %p> %@", [self class], self, params];
+}
+
+@end
+
+
+#pragma mark NSURLConnection
+
+@implementation SPDYURLConnectionIntegrationTestHelper
+
+- (void)loadRequest:(NSURLRequest *)request
+{
+    [super loadRequest:request];
+
+    [NSURLConnection connectionWithRequest:request delegate:self];
+
+    [self _waitForRequestToFinish];
+}
+
+#pragma mark NSURLConnection delegate methods
+
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
+{
+    self.response = (NSHTTPURLResponse *)response;
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
+{
+    if (self.data == nil) {
+        self.data = [NSMutableData dataWithData:data];
+    } else {
+        [self.data appendData:data];
+    }
+}
+
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse *)cachedResponse
+{
+    self.willCacheResponse = cachedResponse;
+    return cachedResponse;
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection
+{
+    self.connectionError = nil;
+    [self _finishRequest];
+}
+
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
+{
+    self.connectionError = error;
+    [self _finishRequest];
+}
+
+@end
+
+
+#pragma mark NSURLSession
+
+@implementation SPDYURLSessionIntegrationTestHelper
+{
+    NSURLCache *_cache;
+    NSURLSessionConfiguration *_configuration;
+    NSURLSession *_session;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _cache = [[NSURLCache alloc] initWithMemoryCapacity:1000000 diskCapacity:10000000 diskPath:nil];
+    }
+    return self;
+}
+- (void)loadRequest:(NSMutableURLRequest *)request
+{
+    [super loadRequest:request];
+
+    _configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    _configuration.URLCache = _cache;
+    _configuration.protocolClasses = @[ [SPDYURLSessionProtocol class] ];
+
+    // request cache policy should be set in the NSURLSessionConfiguration, not in the request.
+    // doing that here to simplify the tests.
+    _configuration.requestCachePolicy = request.cachePolicy;
+
+    _session = [NSURLSession sessionWithConfiguration:_configuration delegate:self delegateQueue:nil];
+
+    // Special SPDY hack to get access to the NSURLSessionConfiguration
+    request.SPDYURLSession = _session;
+
+    NSURLSessionDataTask *task = [_session dataTaskWithRequest:request];
+    [task resume];
+
+    [self _waitForRequestToFinish];
+}
+
+#pragma mark NSURLSession delegate methods
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
+{
+    self.response = (NSHTTPURLResponse *)response;
+    completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+    if (self.data == nil) {
+        self.data = [NSMutableData dataWithData:data];
+    } else {
+        [self.data appendData:data];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask willCacheResponse:(NSCachedURLResponse *)proposedResponse completionHandler:(void (^)(NSCachedURLResponse * cachedResponse))completionHandler
+{
+    self.willCacheResponse = proposedResponse;
+    completionHandler(proposedResponse);
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+    // error may be nil
+    self.connectionError = error;
+    [self _finishRequest];
+}
+
+#pragma mark SPDYURLSessionDelegate methods
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didStartLoadingRequest:(NSURLRequest *)request withContext:(id<SPDYProtocolContext>)context
+{
+    self.spdyContext = context;
+}
+
+@end

--- a/SPDYUnitTests/SPDYMockSessionManager.h
+++ b/SPDYUnitTests/SPDYMockSessionManager.h
@@ -1,0 +1,35 @@
+//
+//  SPDYMockSessionManager.h
+//  SPDY
+//
+//  Copyright (c) 2015 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier on 11/30/15.
+//
+
+#import <Foundation/Foundation.h>
+#import "SPDYSessionManager.h"
+
+@class SPDYPushStreamManager;
+@class SPDYStream;
+
+typedef void (^SPDYMockSessionManagerStreamQueuedCallback)(SPDYStream *stream);
+
+@interface SPDYMockSessionManager : SPDYSessionManager
+
+#pragma mark Mock methods
+
+@property (nonatomic, copy) SPDYMockSessionManagerStreamQueuedCallback streamQueuedBlock;
+
++ (void)performSwizzling:(BOOL)performSwizzling;
++ (SPDYMockSessionManager *)shared;
+
+#pragma mark SPDYSessionManager methods
+
+@property (nonatomic, readonly) SPDYPushStreamManager *pushStreamManager;
+
+- (void)queueStream:(SPDYStream *)stream;
+
+@end

--- a/SPDYUnitTests/SPDYMockSessionManager.m
+++ b/SPDYUnitTests/SPDYMockSessionManager.m
@@ -48,14 +48,6 @@
     return instance;
 }
 
-- (instancetype)init
-{
-    self = [super init];
-    if (self != nil) {
-    }
-    return self;
-}
-
 #pragma mark SPDYSessionManager methods
 
 - (SPDYPushStreamManager *)pushStreamManager

--- a/SPDYUnitTests/SPDYMockSessionManager.m
+++ b/SPDYUnitTests/SPDYMockSessionManager.m
@@ -1,0 +1,83 @@
+//
+//  SPDYMockSessionManager.m
+//  SPDY
+//
+//  Copyright (c) 2015 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier on 11/30/15.
+//
+
+#import <Foundation/Foundation.h>
+#import "SPDYMockSessionManager.h"
+#import "SPDYOrigin.h"
+#import "SPDYPushStreamManager.h"
+#import "SPDYStream.h"
+#import <objc/runtime.h>
+
+@implementation SPDYMockSessionManager
+
+#pragma mark Mock methods
+
++ (void)performSwizzling:(BOOL)performSwizzling
+{
+    Method original, swizzle;
+
+    original = class_getClassMethod([SPDYSessionManager class], @selector(localManagerForOrigin:));
+    swizzle = class_getClassMethod([SPDYMockSessionManager class], @selector(swizzled_localManagerForOrigin:));
+    if (performSwizzling) {
+        method_exchangeImplementations(original, swizzle);
+    } else {
+        method_exchangeImplementations(swizzle, original);
+    }
+}
+
++ (SPDYSessionManager *)swizzled_localManagerForOrigin:(SPDYOrigin *)origin
+{
+    return [SPDYMockSessionManager shared];
+}
+
++ (SPDYMockSessionManager *)shared
+{
+    static dispatch_once_t once;
+    static SPDYMockSessionManager *instance;
+    dispatch_once(&once, ^{
+        instance = [[SPDYMockSessionManager alloc] init];
+    });
+    return instance;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self != nil) {
+    }
+    return self;
+}
+
+#pragma mark SPDYSessionManager methods
+
+- (SPDYPushStreamManager *)pushStreamManager
+{
+    // Not needed
+    return nil;
+}
+
+- (void)queueStream:(SPDYStream *)stream
+{
+    // stream.delegate =
+    [stream startWithStreamId:1 sendWindowSize:1000 receiveWindowSize:1000];
+    stream.localSideClosed = YES;
+
+    if (_streamQueuedBlock) {
+        _streamQueuedBlock(stream);
+    }
+
+    // NSURL system won't make the didReceiveResponse callback until either data is received
+    // or the response finishes. At least for iOS 9. Odd. So we'll force the didFinishLoading
+    // callback to flush out the other.
+    stream.remoteSideClosed = YES;
+}
+
+@end

--- a/SPDYUnitTests/SPDYNSURLCachingTest.m
+++ b/SPDYUnitTests/SPDYNSURLCachingTest.m
@@ -1,0 +1,479 @@
+//
+//  SPDYNSURLCachingTest.m
+//  SPDY
+//
+//  Copyright (c) 2015 Twitter, Inc. All rights reserved.
+//  Licensed under the Apache License v2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Created by Kevin Goodier on 11/30/15.
+//
+
+#import <XCTest/XCTest.h>
+#import <Foundation/Foundation.h>
+#import "SPDYIntegrationTestHelper.h"
+#import "SPDYProtocol.h"
+
+// Remove this once CocoaSPDY supports fully-featured caching
+
+@interface SPDYNSURLCachingTest : XCTestCase<NSURLConnectionDelegate, NSURLConnectionDataDelegate>
+@end
+
+@implementation SPDYNSURLCachingTest
+
++ (void)setUp
+{
+    [super setUp];
+    [SPDYIntegrationTestHelper setUp];
+
+    [SPDYURLConnectionProtocol registerOrigin:@"http://example.com"];
+}
+
++ (void)tearDown
+{
+    [super tearDown];
+    [SPDYIntegrationTestHelper tearDown];
+}
+
+- (void)setUp
+{
+    [super setUp];
+    [self resetSharedCache];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    [self resetSharedCache];
+}
+
+- (void)resetSharedCache
+{
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
+}
+
+- (NSArray *)parameterizedTestHelpers
+{
+    // Should behave the same
+    return @[
+             [[SPDYURLConnectionIntegrationTestHelper alloc] init],
+             [[SPDYURLSessionIntegrationTestHelper alloc] init],
+             ];
+}
+
+- (NSArray *)parameterizedTestInputs
+{
+    return @[
+             // Request helper to use                                  Cache policy to use                     Should pull from cache
+             @[ [[SPDYURLConnectionIntegrationTestHelper alloc] init], @(NSURLRequestUseProtocolCachePolicy),  @(NO) ],
+             @[ [[SPDYURLSessionIntegrationTestHelper alloc] init],    @(NSURLRequestUseProtocolCachePolicy),  @(YES) ],
+             @[ [[SPDYURLConnectionIntegrationTestHelper alloc] init], @(NSURLRequestReturnCacheDataElseLoad), @(YES) ],
+             @[ [[SPDYURLSessionIntegrationTestHelper alloc] init],    @(NSURLRequestReturnCacheDataElseLoad), @(YES) ],
+             ];
+}
+
+#pragma mark Tests
+
+#define GET_TEST_PARAMS \
+        SPDYIntegrationTestHelper *testHelper = testParams[0]; \
+        NSURLRequestCachePolicy cachePolicy = [testParams[1] integerValue]; \
+        BOOL shouldPullFromCache = [testParams[2] boolValue]; (void)shouldPullFromCache
+
+- (void)testCacheableResponse_DoesInsertAndLoadFromCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        // Verify response was pulled from cache, not network
+        XCTAssertEqual(testHelper.didLoadFromCache, shouldPullFromCache, @"%@", testHelper);
+    }
+}
+
+- (void)testCachedItem_DoesHaveMetadata
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Verify metadata
+        SPDYMetadata *metadata = [SPDYProtocol metadataForResponse:testHelper.response];
+        XCTAssertNotNil(metadata, @"%@", testHelper);
+        XCTAssertEqual(metadata.loadSource, SPDYLoadSourceNetwork, @"%@", testHelper);
+
+        // Now make request again. Should pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        // Verify response was pulled from cache, not network
+        XCTAssertEqual(testHelper.didLoadFromCache, shouldPullFromCache, @"%@", testHelper);
+
+        // Verify metadata
+        metadata = [SPDYProtocol metadataForResponse:testHelper.response];
+        XCTAssertNotNil(metadata, @"%@", testHelper);
+        XCTAssertEqual(metadata.loadSource,  shouldPullFromCache ? SPDYLoadSourceCache : SPDYLoadSourceNetwork, @"%@", testHelper);
+
+        // Special logic for metadata provided by SPDYProtocolContext
+        if ([testHelper isMemberOfClass:[SPDYURLSessionIntegrationTestHelper class]]) {
+            SPDYURLSessionIntegrationTestHelper *testHelperURLSession = (SPDYURLSessionIntegrationTestHelper *)testHelper;
+            SPDYMetadata *metadata2 = [testHelperURLSession.spdyContext metadata];
+
+            XCTAssertNotNil(metadata2, @"%@", testHelper);
+            XCTAssertEqual(metadata2.loadSource,  shouldPullFromCache ? SPDYLoadSourceCache : SPDYLoadSourceNetwork, @"%@", testHelper);
+        }
+    }
+}
+
+- (void)testWithReturnCacheDontLoadPolicy_DoesFailRequest
+{
+    for (SPDYIntegrationTestHelper *testHelper in [self parameterizedTestHelpers]) {
+        NSLog(@"- using %@", [testHelper class]);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = NSURLRequestReturnCacheDataDontLoad;
+
+        [testHelper loadRequest:request];
+
+        XCTAssertFalse(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didGetError, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+    }
+}
+
+- (void)testWithReturnCacheDontLoadPolicy_DoesUseCacheIfPopulated
+{
+    for (SPDYIntegrationTestHelper *testHelper in [self parameterizedTestHelpers]) {
+        NSLog(@"- using %@", [testHelper class]);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = NSURLRequestUseProtocolCachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should pull from cache.
+        request.cachePolicy = NSURLRequestReturnCacheDataDontLoad;
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromCache, @"%@", testHelper);
+    }
+}
+
+- (void)testWithReloadIgnoringCachePolicy_DoesNotUseCache
+{
+    for (SPDYIntegrationTestHelper *testHelper in [self parameterizedTestHelpers]) {
+        NSLog(@"- using %@", [testHelper class]);
+        [self resetSharedCache];
+
+        // First insert into cache
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = NSURLRequestUseProtocolCachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again with ReloadingIgnoringCache. Should not use cache.
+        request.cachePolicy = NSURLRequestReloadIgnoringCacheData;
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testWith404Response_DoesUseCache
+{
+    for (SPDYIntegrationTestHelper *testHelper in [self parameterizedTestHelpers]) {
+        NSLog(@"- using %@", [testHelper class]);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = NSURLRequestReturnCacheDataElseLoad;
+
+        [testHelper provideResponseWithStatus:404 cacheControl:@"public, max-age=1200" date:[NSDate date]];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromCache, @"%@", testHelper);
+        XCTAssertEqual(testHelper.response.statusCode, 404ul, @"%@", testHelper);
+    }
+}
+
+- (void)testWith500Response_DoesNotUseCache
+{
+    for (SPDYIntegrationTestHelper *testHelper in [self parameterizedTestHelpers]) {
+        NSLog(@"- using %@", [testHelper class]);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = NSURLRequestReturnCacheDataElseLoad;
+
+        [testHelper provideResponseWithStatus:500 cacheControl:@"public, max-age=1200" date:[NSDate date]];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should not pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        // Verify response was pulled from network
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+        XCTAssertEqual(testHelper.response.statusCode, 500ul, @"%@", testHelper);
+    }
+}
+
+- (void)testWithCacheableRequest_WithNoCacheResponse_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideBasicUncacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should not pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testWithNoCacheRequest_WithCacheableResponse_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+        [request addValue:@"no-store, no-cache" forHTTPHeaderField:@"Cache-Control"];
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should not pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testWithNoCacheRequest_WithNoCacheResponse_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+        [request addValue:@"no-store, no-cache" forHTTPHeaderField:@"Cache-Control"];
+
+        [testHelper provideBasicUncacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should not pull from cache.
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testWithDifferentPathRequest_WithCacheableResponse_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again. Should not pull from cache.
+        request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path/other"]];
+        request.cachePolicy = NSURLRequestUseProtocolCachePolicy;
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testWithNoCacheSecondRequest_WithCacheableResponse_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        // This request and response were cacheable. Verify.
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again, but request specifies a reload.
+        [request addValue:@"no-cache" forHTTPHeaderField:@"Cache-Control"];
+        [testHelper reset];
+        [testHelper loadRequest:request];
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+
+        [request addValue:@"max-age=0" forHTTPHeaderField:@"Cache-Control"];
+        [testHelper reset];
+        [testHelper loadRequest:request];
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testWithExpiredItem_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideResponseWithStatus:200 cacheControl:@"public, max-age=1" date:[NSDate dateWithTimeIntervalSinceNow:-2]];
+        [testHelper loadRequest:request];
+
+        // This request and response were cacheable. Verify.
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertTrue(testHelper.didCacheResponse, @"%@", testHelper);
+
+        // Now make request again
+        [testHelper reset];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+    }
+}
+
+- (void)testRequestWithAuthorization_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu, shouldPullFromCache %tu", [testHelper class], cachePolicy, shouldPullFromCache);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+        [request addValue:@"foo" forHTTPHeaderField:@"Authorization"];
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+    }
+}
+
+- (void)testResponseWithNoDate_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu", [testHelper class], cachePolicy);
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideResponseWithStatus:200 cacheControl:@"public,max-age=1200" date:nil];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+    }
+}
+
+- (void)testPOSTRequest_DoesNotUseCache
+{
+    for (NSArray *testParams in [self parameterizedTestInputs]) {
+        GET_TEST_PARAMS;
+        NSLog(@"- using %@, policy %tu", [testHelper class], cachePolicy);
+
+        [self resetSharedCache];
+
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://example.com/test/path"]];
+        request.HTTPMethod = @"POST";
+        request.cachePolicy = cachePolicy;
+
+        [testHelper provideBasicCacheableResponse];
+        [testHelper loadRequest:request];
+
+        XCTAssertTrue(testHelper.didLoadFromNetwork, @"%@", testHelper);
+        XCTAssertFalse(testHelper.didCacheResponse, @"%@", testHelper);
+    }
+}
+
+@end

--- a/SPDYUnitTests/SPDYURLCacheTest.m
+++ b/SPDYUnitTests/SPDYURLCacheTest.m
@@ -30,7 +30,7 @@
 {
     NSURL *url = [[NSURL alloc] initWithString:@"http://example.com/test/path"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{}];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Date":@"Wed, 25 Nov 2015 00:10:13 GMT"}];
 
     NSURLCacheStoragePolicy policy = SPDYCacheStoragePolicy(request, response);
     XCTAssertEqual(policy, NSURLCacheStorageAllowed);
@@ -40,7 +40,7 @@
 {
     NSURL *url = [[NSURL alloc] initWithString:@"http://example.com/test/path"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:404 HTTPVersion:@"1.1" headerFields:@{}];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:404 HTTPVersion:@"1.1" headerFields:@{@"Date":@"Wed, 25 Nov 2015 00:10:13 GMT"}];
 
     NSURLCacheStoragePolicy policy = SPDYCacheStoragePolicy(request, response);
     XCTAssertEqual(policy, NSURLCacheStorageAllowed);
@@ -56,23 +56,23 @@
     XCTAssertEqual(policy, NSURLCacheStorageNotAllowed);
 }
 
-- (void)testCacheAllowedFor200WithNoStoreRequestHeader
+- (void)testCacheNotAllowedFor200WithNoStoreRequestHeader
 {
     NSURL *url = [[NSURL alloc] initWithString:@"http://example.com/test/path"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     [request addValue:@"no-store" forHTTPHeaderField:@"Cache-Control"];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{}];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Date":@"Wed, 25 Nov 2015 00:10:13 GMT"}];
 
     NSURLCacheStoragePolicy policy = SPDYCacheStoragePolicy(request, response);
-    XCTAssertEqual(policy, NSURLCacheStorageAllowed);
+    XCTAssertEqual(policy, NSURLCacheStorageNotAllowed);
 }
 
 - (void)testCacheNotAllowedFor200WithNoStoreNoCacheRequestHeader
 {
     NSURL *url = [[NSURL alloc] initWithString:@"http://example.com/test/path"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    [request addValue:@"no-store; no-cache" forHTTPHeaderField:@"Cache-Control"];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{}];
+    [request addValue:@"no-store, no-cache" forHTTPHeaderField:@"Cache-Control"];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Date":@"Wed, 25 Nov 2015 00:10:13 GMT"}];
 
     NSURLCacheStoragePolicy policy = SPDYCacheStoragePolicy(request, response);
     XCTAssertEqual(policy, NSURLCacheStorageNotAllowed);
@@ -82,7 +82,7 @@
 {
     NSURL *url = [[NSURL alloc] initWithString:@"http://example.com/test/path"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Cache-Control":@"no-cache"}];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Cache-Control":@"no-cache",@"Date":@"Wed, 25 Nov 2015 00:10:13 GMT"}];
 
     NSURLCacheStoragePolicy policy = SPDYCacheStoragePolicy(request, response);
     XCTAssertEqual(policy, NSURLCacheStorageAllowed);
@@ -92,7 +92,7 @@
 {
     NSURL *url = [[NSURL alloc] initWithString:@"http://example.com/test/path"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Cache-Control":@"no-store"}];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Cache-Control":@"no-store",@"Date":@"Wed, 25 Nov 2015 00:10:13 GMT"}];
 
     NSURLCacheStoragePolicy policy = SPDYCacheStoragePolicy(request, response);
     XCTAssertEqual(policy, NSURLCacheStorageNotAllowed);


### PR DESCRIPTION
The NSURL loading system has subtle and poorly documented behavior
regarding caching. CocoaSPDY was not doing the right thing, thus
there was no support for NSURLCache in the protocol. This patch
adds basic support for both NSURLConnection and NSURLSession based
requests. This is not yet a fully-featured client caching
implementation.

If the request specifies a NSURLRequest cachePolicy of:

NSURLRequestUseProtocolCachePolicy
- NSURL system does not provide a cached response to the protocol
  constructor. It is up to the protocol to load and validate the
  cached response.

NSURLRequestReturnCacheDataElseLoad
- NSURL system will provide the cached response, if available. The
  protocol is expected to validate the response, and load if not
  available or not valid.

NSURLRequestReturnCacheDataDontLoad
- NSURL system will provide the cached response, if available. The
  protocol is expected to validate the response. The protocol will not
  be loaded if no cached response is available, or if one is but is
  invalid, the protocol should not load the request.

In the cases where the protocol has a cached response and it is valid,
it is supposed to call URLProtocol:cachedResponseIsValid. CocoaSPDY
was not doing this. Determining validity of the cached response is the
job of the protocol, and a basic implementation has been provided here.

CocoaSPDY also has to jump through some hoops whenever NSURLSession is
being used, as Apple has not provided a way to get the
NSURLSessionConfiguration and thus we cannot get the right NSURLCache.
Fortunately we have already provided a workaround for this.

SPDYMetadata has been extended to provide the source of the response.

Observationally, we've seen the NSURL loading system fail to insert
items into the NSURLCache when using NSURLSession and iOS 7/8.
NSURLConnection works fine on all these, and NSURLSession works fine on
iOS 9. Best guess is there's a bug in the NSURLProtocol implementation
that fails to insert into the cache.

So, here we are creating a workaround for that specific case. CocoaSPDY
will buffer the data internally, up to a certain size limit based on the
cache size, and will manually insert into the cache when the response is
done. This could potentially be expanded in the future for unclaimed,
finished push responses, but for now those are excluded.
