### PR TITLE
Gracefully handle multiple ":status" headers

### DIFF
--- a/SPDY/SPDYDefinitions.h
+++ b/SPDY/SPDYDefinitions.h
@@ -93,3 +93,6 @@ static const uint8_t SPDY_SETTINGS_FLAG_PERSISTED      = 0x02;
 
 #define SPDY_CODEC_ERROR(CODE, MESSAGE) \
 [[NSError alloc] initWithDomain:SPDYCodecErrorDomain code:CODE userInfo:@{ NSLocalizedDescriptionKey: MESSAGE}]
+
+#define SPDY_NSURL_ERROR(CODE, MESSAGE) \
+[[NSError alloc] initWithDomain:NSURLErrorDomain code:CODE userInfo:@{ NSLocalizedDescriptionKey: MESSAGE}]

--- a/SPDYUnitTests/SPDYFrameCodecTest.m
+++ b/SPDYUnitTests/SPDYFrameCodecTest.m
@@ -334,6 +334,27 @@ NSDictionary *testHeaders()
     }
 }
 
+- (void)testSynReplyFrameWithDuplicateHeaders
+{
+    SPDYSynReplyFrame *inFrame = [[SPDYSynReplyFrame alloc] init];
+    inFrame.streamId = arc4random() & 0x7FFFFFFF;
+    inFrame.last = (bool)(arc4random() & 1);
+    inFrame.headers = @{
+        @":status"  : @[@"200", @"300"],
+        @":version" : @"HTTP/1.1",
+    };
+
+    NSInteger bytesEncoded = [_encoder encodeSynReplyFrame:inFrame error:nil];
+    XCTAssertTrue(bytesEncoded > 12);
+
+    SPDYSynReplyFrame *outFrame = _mock.lastFrame;
+
+    XCTAssertTrue([outFrame.headers[@":status"] isKindOfClass:[NSArray class]]);
+    XCTAssertEqualObjects(@"200", outFrame.headers[@":status"][0]);
+    XCTAssertEqualObjects(@"300", outFrame.headers[@":status"][1]);
+    XCTAssertEqualObjects(@"HTTP/1.1", outFrame.headers[@":version"]);
+}
+
 - (void)testRstStreamFrame
 {
     SPDYRstStreamFrame *inFrame = [[SPDYRstStreamFrame alloc] init];

--- a/SPDYUnitTests/SPDYStreamTest.m
+++ b/SPDYUnitTests/SPDYStreamTest.m
@@ -130,6 +130,19 @@ static NSThread *_streamThread;
     SPDYAssertStreamError(NSURLErrorDomain, NSURLErrorBadServerResponse);
 }
 
+- (void)testReceiveResponseMultipleStatusCodeDoesAbort
+{
+    SPDYStream *stream = [self createStream];
+    [stream startWithStreamId:1 sendWindowSize:1024 receiveWindowSize:1024];
+
+    NSDictionary *headers = @{@":scheme":@"http", @":host":@"mocked", @":path":@"/init",
+                              @":status":@[@"200", @"300"], @":version":@"http/1.1"};
+
+    [stream mergeHeaders:headers];
+    [stream didReceiveResponse];
+    SPDYAssertStreamError(NSURLErrorDomain, NSURLErrorBadServerResponse);
+}
+
 - (void)testReceiveResponseMissingVersionDoesAbort
 {
     SPDYStream *stream = [self createStream];


### PR DESCRIPTION
The server should never return multiple ":status" header values, but
if it does happen, we should abort the response rather than crash.
This seems better than arbitrariliy choosing the first value and
continuing on.