### PR TITLE
use stdatomic for log levels

### DIFF
--- a/SPDY/SPDYCommonLogger.h
+++ b/SPDY/SPDYCommonLogger.h
@@ -9,12 +9,14 @@
 //  Created by Michael Schore and Jeffrey Pinner.
 //
 
+#include <stdatomic.h>
+
 #import <Foundation/Foundation.h>
 #import "SPDYLogger.h"
 
-extern volatile SPDYLogLevel __sharedLoggerLevel;
+extern volatile atomic_int_fast32_t __sharedLoggerLevel;
 
-#define LOG_LEVEL_ENABLED(l) ((l) <= __sharedLoggerLevel)
+#define LOG_LEVEL_ENABLED(l) ((l) <= atomic_load(&__sharedLoggerLevel))
 
 #define SPDY_DEBUG(message, ...) do { \
     if (LOG_LEVEL_ENABLED(SPDYLogLevelDebug)) { \

--- a/SPDY/SPDYLogger.h
+++ b/SPDY/SPDYLogger.h
@@ -11,13 +11,13 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum {
+typedef NS_ENUM(int32_t, SPDYLogLevel) {
     SPDYLogLevelDisabled = -1,
     SPDYLogLevelError = 0,
     SPDYLogLevelWarning,
     SPDYLogLevelInfo,
     SPDYLogLevelDebug
-} SPDYLogLevel;
+};
 
 @protocol SPDYLogger <NSObject>
 - (void)log:(NSString *)message atLevel:(SPDYLogLevel)logLevel;


### PR DESCRIPTION
There are thread sanitizer errors if log levels are not atomic in mutation