### PR TITLE
ignore setLoggerLevel: when compiling w/thread-sanitizer on

### DIFF
--- a/SPDY/SPDYCommonLogger.m
+++ b/SPDY/SPDYCommonLogger.m
@@ -54,6 +54,12 @@ volatile atomic_int_fast32_t __sharedLoggerLevel;
 }
 
 + (void)setLoggerLevel:(SPDYLogLevel)level
+#if defined(__has_feature)
+#  if __has_feature(thread_sanitizer)
+// not performing thread-sanitizer on this because __sharedLoggerLevel has been declared volatile
+ __attribute__((no_sanitize("thread")))
+#  endif // #  if __has_Feature(thread_sanitizer)
+#endif // #if defined(__has_feature)
 {
     atomic_store(&__sharedLoggerLevel, level);
 }


### PR DESCRIPTION
during unit-testing with the thread-sanitizer on, setLoggerLevel: was
flagged unnecessarily as a potential data-race.

__sharedLoggerLevel is already marked volatile, and the location of
the data race indicated was a debug logging message .